### PR TITLE
use #assemble in ctor

### DIFF
--- a/src/ctor.eas
+++ b/src/ctor.eas
@@ -7,5 +7,5 @@ push0
 return
 
 .start:
-#include "main.eas"
+#assemble "main.eas"
 .end:


### PR DESCRIPTION
Using `#include` is wrong because labels in the deployed code will have the wrong offset. This is why we have `#assemble` in geas. It compiles the included file as a new program (with labels starting at zero), then inserts the bytecode at the `#assemble` directive position.