### PR TITLE
Add inhibitor to queue before activation

### DIFF
--- a/src/ctor.eas
+++ b/src/ctor.eas
@@ -1,3 +1,11 @@
+;; Store 1181 as a temporary excess value as it creates a fee so large that no
+;; request will be accepted in the queue until after 7002 is activated and
+;; called by the system for the first time
+push 1181
+push0
+sstore
+
+;; Copy and return code.
 push @.end - @.start
 dup1
 push @.start

--- a/src/ctor.eas
+++ b/src/ctor.eas
@@ -1,6 +1,6 @@
 ;; Store 1181 as a temporary excess value as it creates a fee so large that no
 ;; request will be accepted in the queue until after 7002 is activated and
-;; called by the system for the first time
+;; called by the system for the first time.
 push 1181
 push0
 sstore

--- a/src/main.eas
+++ b/src/main.eas
@@ -325,6 +325,19 @@ update_excess:
   ;; Update the new excess withdrawal requests.
   push SLOT_EXCESS      ;; [excess_slot, count]
   sload                 ;; [excess, count]
+  
+  ;; Check if excess needs to be reset to 0 for first iteration after
+  ;; activation.
+  dup1                  ;; [excess, excess, count, count]
+  push 1181             ;; [1181, excess, excess, count, count]
+  eq                    ;; [1181 == excess, excess, count, count]
+  iszero                ;; [1181 != excess, excess, count, count]
+  jumpi @skip_reset     ;; [excess, count, count]
+
+  pop                   ;; [count, count]
+  push0                 ;; [reset_excess, count]
+
+skip_reset:
   push SLOT_COUNT       ;; [count_slot, excess, count]
   sload                 ;; [count, excess, count]
 

--- a/src/main.eas
+++ b/src/main.eas
@@ -34,7 +34,7 @@
 #define TARGET_PER_BLOCK 2
 #define MAX_PER_BLOCK 16
 #define FEE_UPDATE_FRACTION 17
-#define EXCESS_INHIBITOR = 1181
+#define EXCESS_INHIBITOR 1181
 
 #define INPUT_SIZE 56   ;; the size of (pubkey ++ amount)
 #define RECORD_SIZE 76  ;; the size of (address ++ pubkey ++ amount)

--- a/src/main.eas
+++ b/src/main.eas
@@ -34,6 +34,7 @@
 #define TARGET_PER_BLOCK 2
 #define MAX_PER_BLOCK 16
 #define FEE_UPDATE_FRACTION 17
+#define EXCESS_INHIBITOR = 1181
 
 #define INPUT_SIZE 56   ;; the size of (pubkey ++ amount)
 #define RECORD_SIZE 76  ;; the size of (address ++ pubkey ++ amount)
@@ -329,11 +330,12 @@ update_excess:
   ;; Check if excess needs to be reset to 0 for first iteration after
   ;; activation.
   dup1                  ;; [excess, excess, count, count]
-  push 1181             ;; [1181, excess, excess, count, count]
-  eq                    ;; [1181 == excess, excess, count, count]
-  iszero                ;; [1181 != excess, excess, count, count]
+  push EXCESS_INHIBITOR ;; [inhibitor, excess, excess, count, count]
+  eq                    ;; [inhibitor == excess, excess, count, count]
+  iszero                ;; [inhibitor != excess, excess, count, count]
   jumpi @skip_reset     ;; [excess, count, count]
 
+  ;; Drop the excess from storage and use 0.
   pop                   ;; [count, count]
   push0                 ;; [reset_excess, count]
 

--- a/test/Contract.t.sol.in
+++ b/test/Contract.t.sol.in
@@ -147,6 +147,24 @@ contract ContractTest is Test {
 
   }
 
+  // testInhibitorRest verifies that after the first system call the excess
+  // value is reset to 0.
+  function testInhibitorReset() public {
+    vm.store(addr, bytes32(0), bytes32(uint256(1181)));
+    vm.prank(sysaddr);
+    (bool ret, bytes memory data) = addr.call("");
+    assertStorage(excess_slot, 0, "expected excess requests to be reset");
+
+    vm.store(addr, bytes32(0), bytes32(uint256(1180)));
+    vm.prank(sysaddr);
+    (ret, data) = addr.call("");
+    assertStorage(excess_slot, 1180-target_per_block, "didn't expect excess to be reset");
+  }
+
+  // --------------------------------------------------------------------------
+  // helpers ------------------------------------------------------------------
+  // --------------------------------------------------------------------------
+
   function min(uint256 x, uint256 y) internal pure returns (uint256) {
     if (x < y) {
       return x;


### PR DESCRIPTION
This PR implements a features first requested by @marioevz.

The concern is that before 7002 becomes active, it would be possible to join the queue without `excess` growing. This means the queue could be filled extremely cheaply.

To avoid this, we set the value of `excess` to an extremely high value so that no user could ever pay a fee to enter the queue. This avoids additional `sloads` during normal operations.

We chose `1181` as the value of `excess` because i) it a prime and ii) `fake_exponential(1, 1181, 17) = 1481455745989958413761130954915 wei` which is more than 1 trillion eth. That's more eth than will (hopefully) ever exist.

Each system call will check `excess == 1181` and use `0` in it's place if so. This of course will only be true for the first call following activation of Prague.