### PR TITLE
Add logging to system contracts

### DIFF
--- a/src/consolidations/main.eas
+++ b/src/consolidations/main.eas
@@ -141,6 +141,23 @@ check_input:
   swap1                 ;; [slot, target[16:48], ..]
   sstore                ;; [..]
 
+
+  ;; Assemble log data.
+  caller                ;; [caller, ..]
+  push1 96              ;; [96, caller, ..]
+  shl                   ;; [caller, ..]
+  push0                 ;; [0, caller, ..]
+  mstore                ;; [..]
+  push1 INPUT_SIZE      ;; [size, ..]
+  push0                 ;; [ost, size, ..]
+  push1 20              ;; [dest, ost, size, ..]
+  calldatacopy          ;; [..]
+
+  ;; Log record.
+  push1 RECORD_SIZE     ;; [size, ..]
+  push0                 ;; [idx, size, ..]
+  log0                  ;; [..]
+
   ;; Increment queue tail over last and write to storage.
   push1 1               ;; [1, tail_idx]
   add                   ;; [tail_idx+1]

--- a/src/withdrawals/main.eas
+++ b/src/withdrawals/main.eas
@@ -142,6 +142,22 @@ check_input:
   swap1                 ;; [slot, pk2_am, ..]
   sstore                ;; [..]
 
+  ;; Assemble log data.
+  caller                ;; [caller, ..]
+  push1 96              ;; [96, caller, ..]
+  shl                   ;; [caller, ..]
+  push0                 ;; [0, caller, ..]
+  mstore                ;; [..]
+  push1 INPUT_SIZE      ;; [size, ..]
+  push0                 ;; [ost, size, ..]
+  push1 20              ;; [dest, ost, size, ..]
+  calldatacopy          ;; [..]
+
+  ;; Log record.
+  push1 RECORD_SIZE     ;; [size, ..]
+  push0                 ;; [idx, size, ..]
+  log0                  ;; [..]
+
   ;; Increment queue tail over last and write to storage.
   push1 1               ;; [1, tail_idx]
   add                   ;; [tail_idx+1]

--- a/test/Consolidation.t.sol.in
+++ b/test/Consolidation.t.sol.in
@@ -33,17 +33,18 @@ contract ConsolidationTest is Test {
   function testConsolidation() public {
     bytes memory data = hex"111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222";
 
-    vm.expectEmit(false, false, false, true);
+    vm.expectEmitAnonymous(false, false, false, false, true);
     assembly {
       let ptr := mload(0x40)
       mstore(ptr, shl(96, address()))
       mstore(add(ptr, 20), mload(add(data, 32)))
       mstore(add(ptr, 52), mload(add(data, 64)))
-      log0(ptr, 76)
+      mstore(add(ptr, 84), mload(add(data, 96)))
+      log0(ptr, 116)
     }
 
     (bool ret,) = addr.call{value: 2}(data);
-    assertEq(ret, true);
+    assertEq(ret, true, "call failed");
     assertStorage(count_slot, 1, "unexpected request count");
     assertExcess(0);
 

--- a/test/Consolidation.t.sol.in
+++ b/test/Consolidation.t.sol.in
@@ -32,6 +32,16 @@ contract ConsolidationTest is Test {
   // request count is accepted and read successfully.
   function testConsolidation() public {
     bytes memory data = hex"111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222";
+
+    vm.expectEmit(false, false, false, true);
+    assembly {
+      let ptr := mload(0x40)
+      mstore(ptr, shl(96, address()))
+      mstore(add(ptr, 20), mload(add(data, 32)))
+      mstore(add(ptr, 52), mload(add(data, 64)))
+      log0(ptr, 76)
+    }
+
     (bool ret,) = addr.call{value: 2}(data);
     assertEq(ret, true);
     assertStorage(count_slot, 1, "unexpected request count");

--- a/test/Withdrawal.t.sol.in
+++ b/test/Withdrawal.t.sol.in
@@ -35,7 +35,7 @@ contract WithdrawalsTest is Test {
   function testWithdrawal() public {
     bytes memory data = hex"1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112222222222222222";
 
-    vm.expectEmit(false, false, false, true);
+    vm.expectEmitAnonymous(false, false, false, false, true);
     assembly {
       let ptr := mload(0x40)
       mstore(ptr, shl(96, address()))

--- a/test/Withdrawal.t.sol.in
+++ b/test/Withdrawal.t.sol.in
@@ -34,6 +34,16 @@ contract WithdrawalsTest is Test {
   // count is accepted and read successfully.
   function testWithdrawal() public {
     bytes memory data = hex"1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111112222222222222222";
+
+    vm.expectEmit(false, false, false, true);
+    assembly {
+      let ptr := mload(0x40)
+      mstore(ptr, shl(96, address()))
+      mstore(add(ptr, 20), mload(add(data, 32)))
+      mstore(add(ptr, 52), mload(add(data, 64)))
+      log0(ptr, 76)
+    }
+
     (bool ret,) = addr.call{value: 2}(data);
     assertEq(ret, true);
     assertStorage(count_slot, 1, "unexpected request count");


### PR DESCRIPTION
In [ACD 191](https://github.com/ethereum/pm/issues/1080#issuecomment-2200199789) we discussed the idea of adding logging to the system contracts. There wasn't much push back so I've gone ahead and implemented it.

Waiting on a resolution for https://github.com/foundry-rs/foundry/issues/8416 before merging to ensure tests pass correctly.