### PR TITLE
src/beacon_root: gas optimization

### DIFF
--- a/src/beacon_root/main.eas
+++ b/src/beacon_root/main.eas
@@ -131,5 +131,3 @@ submit:
         push3 BUFLEN     ;; [buflen, time_index, root]
         add              ;; [root_index, root]
         sstore           ;; []
-
-        stop             ;; []

--- a/src/beacon_root/main.eas
+++ b/src/beacon_root/main.eas
@@ -72,11 +72,12 @@ loadtime:
         calldataload     ;; [input_timestamp]
         dup1             ;; [input_timestamp, input_timestamp]
 
-        ;; Verify input timestamp is non-zero.
-        iszero           ;; [input_timestamp == 0, input_timestamp]
-        push1 @throw      ;; [throw_lbl, input_timestamp == 0, input_timestamp]
+        ;; Jump to continue if timestamp is non-zero, otherwise revert.
+        push1 @time_ok   ;; [time_ok_lbl, input_timestamp, input_timestamp]
         jumpi            ;; [input_timestamp]
+        %do_revert()     ;; []
 
+time_ok:
         ;; Compute the timestamp index and load from storage.
         push3 BUFLEN     ;; [buflen, input_timestamp]
         dup2             ;; [input_timestamp, buflen, input_timestamp]
@@ -107,10 +108,6 @@ loadroot:
         push1 32         ;; [size]
         push0            ;; [offset, size]
         return           ;; []
-
-throw:
-        ;; Reverts current execution with no return data.
-        %do_revert()
 
 submit:
         ;; Calculate the index the timestamp should be stored at, e.g.


### PR DESCRIPTION
This PR is a small gas optimization for the beacon_root-contract.

* dropped `stop` at the end of the contract: the execution stops, if the end of the contract is reached. an explicit `stop` at the end is not required.
* dropped `iszero`: `jumpi` jumps, if the condition is non-zero. thus, the `input_timestamp` can be used as the condition directly. This reduces the gas consumption of the execution with valid input data by 2 (-3 for dropping the `iszero`, +1 for an extra `jumpdest`)