### PR TITLE
Update excess fee inhibitor to `65536`

### DIFF
--- a/src/consolidations/ctor.eas
+++ b/src/consolidations/ctor.eas
@@ -1,7 +1,7 @@
-;; Store 1181 as a temporary excess value as it creates a fee so large that no
+;; Store 65536 as a temporary excess value as it creates a fee so large that no
 ;; request will be accepted in the queue until after 7002 is activated and
 ;; called by the system for the first time.
-push 1181
+push 65536
 push0
 sstore
 

--- a/src/consolidations/main.eas
+++ b/src/consolidations/main.eas
@@ -24,7 +24,7 @@
 #define TARGET_PER_BLOCK 1
 #define MAX_PER_BLOCK 1
 #define FEE_UPDATE_FRACTION 17
-#define EXCESS_INHIBITOR 1181
+#define EXCESS_INHIBITOR 65536
 
 #define INPUT_SIZE 96    ;; the size of (source ++ target)
 #define RECORD_SIZE 116  ;; the size of (address ++ source ++ target)

--- a/src/withdrawals/ctor.eas
+++ b/src/withdrawals/ctor.eas
@@ -1,7 +1,7 @@
-;; Store 1181 as a temporary excess value as it creates a fee so large that no
+;; Store 65536 as a temporary excess value as it creates a fee so large that no
 ;; request will be accepted in the queue until after 7002 is activated and
 ;; called by the system for the first time.
-push 1181
+push 65536
 push0
 sstore
 

--- a/src/withdrawals/main.eas
+++ b/src/withdrawals/main.eas
@@ -34,7 +34,7 @@
 #define TARGET_PER_BLOCK 2
 #define MAX_PER_BLOCK 16
 #define FEE_UPDATE_FRACTION 17
-#define EXCESS_INHIBITOR 1181
+#define EXCESS_INHIBITOR 65536
 
 #define INPUT_SIZE 56   ;; the size of (pubkey ++ amount)
 #define RECORD_SIZE 76  ;; the size of (address ++ pubkey ++ amount)

--- a/test/Consolidation.t.sol.in
+++ b/test/Consolidation.t.sol.in
@@ -146,15 +146,15 @@ contract ConsolidationTest is Test {
   // testInhibitorRest verifies that after the first system call the excess
   // value is reset to 0.
   function testInhibitorReset() public {
-    vm.store(addr, bytes32(0), bytes32(uint256(1181)));
+    vm.store(addr, bytes32(0), bytes32(uint256(65536)));
     vm.prank(sysaddr);
     (bool ret, bytes memory data) = addr.call("");
     assertStorage(excess_slot, 0, "expected excess requests to be reset");
 
-    vm.store(addr, bytes32(0), bytes32(uint256(1180)));
+    vm.store(addr, bytes32(0), bytes32(uint256(65535)));
     vm.prank(sysaddr);
     (ret, data) = addr.call("");
-    assertStorage(excess_slot, 1180-target_per_block, "didn't expect excess to be reset");
+    assertStorage(excess_slot, 65535-target_per_block, "didn't expect excess to be reset");
   }
 
   // --------------------------------------------------------------------------

--- a/test/FakeExpo.t.sol.in
+++ b/test/FakeExpo.t.sol.in
@@ -11,5 +11,6 @@ contract FakeExpoTest is Test {
   // testFakeExpo calls the fake exponentiation logic with specific values.
   function testFakeExpo() public {
     assertEq(callFakeExpo(1, 100, 17), 357);
+    assertEq(callFakeExpo(1, 65536, 17), 923226766505217739920341538189009691485399699651503388307248448916147782597);
   }
 }

--- a/test/Withdrawal.t.sol.in
+++ b/test/Withdrawal.t.sol.in
@@ -144,15 +144,15 @@ contract WithdrawalsTest is Test {
   // testInhibitorRest verifies that after the first system call the excess
   // value is reset to 0.
   function testInhibitorReset() public {
-    vm.store(addr, bytes32(0), bytes32(uint256(1181)));
+    vm.store(addr, bytes32(0), bytes32(uint256(65536)));
     vm.prank(sysaddr);
     (bool ret, bytes memory data) = addr.call("");
     assertStorage(excess_slot, 0, "expected excess requests to be reset");
 
-    vm.store(addr, bytes32(0), bytes32(uint256(1180)));
+    vm.store(addr, bytes32(0), bytes32(uint256(65535)));
     vm.prank(sysaddr);
     (ret, data) = addr.call("");
-    assertStorage(excess_slot, 1180-target_per_block, "didn't expect excess to be reset");
+    assertStorage(excess_slot, 65535-target_per_block, "didn't expect excess to be reset");
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
Back in #12 we realized that we need to keep users from submitting requests before fork. The simple way to do this is add a flag to the system contract and set the flag the first time the system call happens.

The downside is that the flag gate imposes an extra 5000 gas on ever user call to the contract forever in the future.

To avoid this, we decided to make the fee too great for anyone to actually pay before the fork. On the first system call, the contract will notice the excess count is the special value and reset it to zero.

We stick with that idea in this PR, but update the value from `1181` to `16384`. Originally `1181` was decided because it's the largest value we can use in `fake_exponential` without it overflowing. Unfortunately we realized that `1181` is a number that might be possible to obtain in the future. The cost is bound mostly by the five `sstores` in the user routine. If the gas limit changes significantly or storage becomes much cheaper, it's possible to imagine a world where post-Prague, a user could submit 1181 requests in a single block at 1 wei and avoid the fee spike from occurring.

To address this, I'm proposing we bump to `65536`. This number is proposed somewhat arbitrarily, but it returns a fee of `923226766505217739920341538189009691485399699651503388307248448916147782597` -- so safe to say even though it does overflow during the calculation, it produces a fee that is also impossible to meet before the fork and increases the number of requests needed to organically trigger the short circuit by an order of magnitude.

If we're okay with relying on this fee calculation overflowing, we could potentially choose an even larger number for this inhibitor. Part of the reason I picked this value is foundry seems to have issues with arbitrarily large numbers here.