### PR TITLE
Gate pre-fork requests on max uint256 excess inhibitor

### DIFF
--- a/src/consolidations/ctor.eas
+++ b/src/consolidations/ctor.eas
@@ -1,7 +1,6 @@
-;; Store 1181 as a temporary excess value as it creates a fee so large that no
-;; request will be accepted in the queue until after 7002 is activated and
-;; called by the system for the first time.
-push 1181
+;; Store 0xff..ff as a temporary excess value to avoid requests being queued
+;; before the fork.
+push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 push0
 sstore
 

--- a/src/consolidations/main.eas
+++ b/src/consolidations/main.eas
@@ -24,7 +24,7 @@
 #define TARGET_PER_BLOCK 1
 #define MAX_PER_BLOCK 1
 #define FEE_UPDATE_FRACTION 17
-#define EXCESS_INHIBITOR 1181
+#define EXCESS_INHIBITOR 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 
 #define INPUT_SIZE 96    ;; the size of (source ++ target)
 #define RECORD_SIZE 116  ;; the size of (address ++ source ++ target)
@@ -84,6 +84,13 @@ check_input:
   push FEE_UPDATE_FRACTION
   push SLOT_EXCESS      ;; [excess_slot, update_fraction]
   sload                 ;; [excess, update_fraction]
+
+  ;; Check if the pre-fork inhibitor is still active, revert if so.
+  dup1                  ;; [excess, excess, update_fraction]
+  push EXCESS_INHIBITOR ;; [inhibitor, excess, excess, update_fraction]
+  eq                    ;; [inhibitor == excess, excess, update_fraction]
+  jumpi @revert         ;; [excess, update_fraction]
+
   push MIN_FEE          ;; [min_fee, excess, update_fraction]
   #include "../common/fake_expo.eas"
 

--- a/src/withdrawals/ctor.eas
+++ b/src/withdrawals/ctor.eas
@@ -1,7 +1,6 @@
-;; Store 1181 as a temporary excess value as it creates a fee so large that no
-;; request will be accepted in the queue until after 7002 is activated and
-;; called by the system for the first time.
-push 1181
+;; Store 0xff..ff as a temporary excess value to avoid requests being queued
+;; before the fork.
+push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 push0
 sstore
 

--- a/src/withdrawals/main.eas
+++ b/src/withdrawals/main.eas
@@ -34,7 +34,7 @@
 #define TARGET_PER_BLOCK 2
 #define MAX_PER_BLOCK 16
 #define FEE_UPDATE_FRACTION 17
-#define EXCESS_INHIBITOR 1181
+#define EXCESS_INHIBITOR 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 
 #define INPUT_SIZE 56   ;; the size of (pubkey ++ amount)
 #define RECORD_SIZE 76  ;; the size of (address ++ pubkey ++ amount)
@@ -94,6 +94,13 @@ check_input:
   push FEE_UPDATE_FRACTION
   push SLOT_EXCESS      ;; [excess_slot, update_fraction]
   sload                 ;; [excess, update_fraction]
+
+  ;; Check if the pre-fork inhibitor is still active, revert if so.
+  dup1                  ;; [excess, excess, update_fraction]
+  push EXCESS_INHIBITOR ;; [inhibitor, excess, excess, update_fraction]
+  eq                    ;; [inhibitor == excess, excess, update_fraction]
+  jumpi @revert         ;; [excess, update_fraction]
+
   push MIN_FEE          ;; [min_fee, excess, update_fraction]
   #include "../common/fake_expo.eas"
 

--- a/test/Consolidation.t.sol.in
+++ b/test/Consolidation.t.sol.in
@@ -144,13 +144,16 @@ contract ConsolidationTest is Test {
 
   }
 
-  // testInhibitorRest verifies that after the first system call the excess
+  // testInhibitorReset verifies that after the first system call the excess
   // value is reset to 0.
   function testInhibitorReset() public {
     vm.store(addr, bytes32(0), bytes32(inhibitor));
     vm.prank(sysaddr);
     (bool ret, bytes memory data) = addr.call("");
     assertStorage(excess_slot, 0, "expected excess requests to be reset");
+
+    vm.store(addr, bytes32(0), bytes32(inhibitor));
+    addFailedRequest(address(uint160(0)), makeConsolidation(0), inhibitor);
 
     vm.store(addr, bytes32(0), bytes32(inhibitor-1));
     vm.prank(sysaddr);

--- a/test/Consolidation.t.sol.in
+++ b/test/Consolidation.t.sol.in
@@ -5,6 +5,7 @@ import "./Test.sol";
 
 uint256 constant target_per_block = 1;
 uint256 constant max_per_block = 1;
+uint256 constant inhibitor = uint256(bytes32(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
 
 contract ConsolidationTest is Test {
 
@@ -146,15 +147,15 @@ contract ConsolidationTest is Test {
   // testInhibitorRest verifies that after the first system call the excess
   // value is reset to 0.
   function testInhibitorReset() public {
-    vm.store(addr, bytes32(0), bytes32(uint256(1181)));
+    vm.store(addr, bytes32(0), bytes32(inhibitor));
     vm.prank(sysaddr);
     (bool ret, bytes memory data) = addr.call("");
     assertStorage(excess_slot, 0, "expected excess requests to be reset");
 
-    vm.store(addr, bytes32(0), bytes32(uint256(1180)));
+    vm.store(addr, bytes32(0), bytes32(inhibitor-1));
     vm.prank(sysaddr);
     (ret, data) = addr.call("");
-    assertStorage(excess_slot, 1180-target_per_block, "didn't expect excess to be reset");
+    assertStorage(excess_slot, inhibitor-target_per_block-1, "didn't expect excess to be reset");
   }
 
   // --------------------------------------------------------------------------

--- a/test/Withdrawal.t.sol.in
+++ b/test/Withdrawal.t.sol.in
@@ -5,6 +5,7 @@ import "./Test.sol";
 
 uint256 constant target_per_block = 2;
 uint256 constant max_per_block = 16;
+uint256 constant inhibitor = uint256(bytes32(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff));
 
 contract WithdrawalsTest is Test {
   address unit;
@@ -147,15 +148,18 @@ contract WithdrawalsTest is Test {
   // testInhibitorRest verifies that after the first system call the excess
   // value is reset to 0.
   function testInhibitorReset() public {
-    vm.store(addr, bytes32(0), bytes32(uint256(1181)));
+    vm.store(addr, bytes32(0), bytes32(inhibitor));
     vm.prank(sysaddr);
     (bool ret, bytes memory data) = addr.call("");
     assertStorage(excess_slot, 0, "expected excess requests to be reset");
 
-    vm.store(addr, bytes32(0), bytes32(uint256(1180)));
+    vm.store(addr, bytes32(0), bytes32(inhibitor));
+    addFailedRequest(address(uint160(0)), makeWithdrawal(0), inhibitor);
+
+    vm.store(addr, bytes32(0), bytes32(inhibitor-1));
     vm.prank(sysaddr);
     (ret, data) = addr.call("");
-    assertStorage(excess_slot, 1180-target_per_block, "didn't expect excess to be reset");
+    assertStorage(excess_slot, inhibitor-target_per_block-1, "didn't expect excess to be reset");
   }
 
   // --------------------------------------------------------------------------

--- a/test/Withdrawal.t.sol.in
+++ b/test/Withdrawal.t.sol.in
@@ -145,7 +145,7 @@ contract WithdrawalsTest is Test {
 
   }
 
-  // testInhibitorRest verifies that after the first system call the excess
+  // testInhibitorReset verifies that after the first system call the excess
   // value is reset to 0.
   function testInhibitorReset() public {
     vm.store(addr, bytes32(0), bytes32(inhibitor));


### PR DESCRIPTION
h/t @mkalinin for the alternative idea to #23 

--

Instead of gating pre-fork requests via the computed fee, Mikhail had the idea that we can just revert if during the calculation we find the current excess value to be `0xff..ff`. It's a much smaller amount of overhead versus using a separate storage slot to signal the fork has passed, but also avoid the possibility of retriggering the reset condition post-fork.