### PR TITLE
withdrawals, consolidations: return fee instead of excess requests from read operation

### DIFF
--- a/src/consolidations/main.eas
+++ b/src/consolidations/main.eas
@@ -1,7 +1,7 @@
-;; ▗▄▄▄▖▄▄▄▄ ▄▄▄▄ ▄ ▗▞▀▜▌ ▄▄▄  
-;;    ▐▌   █ █    █ ▝▚▄▟▌▀▄▄  ▄▄▄▄          
-;;    ▐▌█▀▀▀ ▀▀▀█ █      ▄▄▄▀ █ █ █         
-;;    ▐▌█▄▄▄ ▄▄▄█ █           █   █              
+;; ▗▄▄▄▖▄▄▄▄ ▄▄▄▄ ▄ ▗▞▀▜▌ ▄▄▄
+;;    ▐▌   █ █    █ ▝▚▄▟▌▀▄▄  ▄▄▄▄
+;;    ▐▌█▀▀▀ ▀▀▀█ █      ▄▄▄▀ █ █ █
+;;    ▐▌█▄▄▄ ▄▄▄█ █           █   █
 
 ;; This is an implementation of EIP-7251 style contract handling EL triggerred
 ;; consolidations. It leverages on the fee mechanism and the queue design of the
@@ -50,29 +50,6 @@
   ;; --------------------------------------------------------------------------
   ;; USER SUBROUTINE ----------------------------------------------------------
   ;; --------------------------------------------------------------------------
-  ;;
-  ;; Record new request ~~
-  ;; This is the default code path. It will attempt to record a user's request
-  ;; so long as they pay the required fee.
-
-  ;; If calldatasize == 0, return the current excess requests.
-  calldatasize          ;; [calldatasize]
-  iszero                ;; [calldatasize == 0]
-  jumpi @read_excess
-
-  ;; Input data has the following layout:
-  ;;
-  ;;  +--------+--------+
-  ;;  | source | target |
-  ;;  +--------+--------+
-  ;;      48       48
-
-  ;; Verify the input is exactly INPUT_SIZE bytes.
-  calldatasize          ;; [calldatasize]
-  push INPUT_SIZE       ;; [INPUT_SIZE, calldatasize]
-  eq                    ;; [INPUT_SIZE == calldatasize]
-  iszero                ;; [INPUT_SIZE != calldatasize]
-  jumpi @revert         ;; []
 
   ;; Compute the fee using fake expo and the current excess requests.
   push FEE_UPDATE_FRACTION
@@ -87,6 +64,41 @@
 
   push MIN_FEE          ;; [min_fee, excess, update_fraction]
   #include "../common/fake_expo.eas"
+
+  ;; If calldatasize matches the expected input size, go to adding the request.
+  calldatasize          ;; [calldatasize, req_fee]
+  push INPUT_SIZE       ;; [INPUT_SIZE, calldatasize, req_fee]
+  eq                    ;; [INPUT_SIZE == calldatasize, req_fee]
+  jumpi @handle_input   ;; [req_fee]
+
+  ;; Otherwise calldatasize must be zero.
+  calldatasize          ;; [calldatasize, req_fee]
+  iszero                ;; [calldatasize == 0, req_fee]
+  iszero                ;; [calldatasize != 0, req_fee]
+  jumpi @revert         ;; [req_fee]
+
+  ;; This is the read path, where we return the current excess.
+  ;; Reject any callvalue here to prevent lost funds.
+  callvalue             ;; [value, req_fee]
+  iszero                ;; [value == 0, req_fee]
+  iszero                ;; [value != 0, req_fee]
+  jumpi @revert         ;; [req_fee]
+
+  ;; Load excess requests and return the value.
+  push 0                ;; [0, req_fee]
+  mstore                ;; []
+  push 32               ;; [32]
+  push 0                ;; [0, 32]
+  return                ;; []
+
+handle_input:
+  ;; This is the write path. We expect the computed fee on the stack.
+  ;; Input data has the following layout:
+  ;;
+  ;;  +--------+--------+
+  ;;  | source | target |
+  ;;  +--------+--------+
+  ;;      48       48
 
   ;; Determine if the fee provided is enough to cover the request fee.
   callvalue             ;; [callvalue, req_fee]
@@ -166,23 +178,6 @@
   sstore                ;; []
 
   stop
-
-read_excess:
-  ;; This is the read path, where we return the current excess.
-  ;; Reject any callvalue here to prevent lost funds.
-  callvalue             ;; [value]
-  iszero                ;; [value == 0]
-  iszero                ;; [value != 0]
-  jumpi @revert
-
-  ;; Load excess requests and return the value.
-  push SLOT_EXCESS      ;; [excess_reqs_slot]
-  sload                 ;; [excess_reqs]
-  push 0                ;; [0, excess_reqs]
-  mstore                ;; []
-  push 32               ;; [32]
-  push 0                ;; [0, 32]
-  return                ;; []
 
 ;; ----------------------------------------------------------------------------
 ;; SYSTEM SUBROUTINE ----------------------------------------------------------

--- a/src/consolidations/main.eas
+++ b/src/consolidations/main.eas
@@ -84,7 +84,7 @@
   iszero                ;; [value != 0, req_fee]
   jumpi @revert         ;; [req_fee]
 
-  ;; Load excess requests and return the value.
+  ;; Return req_fee.
   push 0                ;; [0, req_fee]
   mstore                ;; []
   push 32               ;; [32]

--- a/src/consolidations/main.eas
+++ b/src/consolidations/main.eas
@@ -73,15 +73,11 @@
 
   ;; Otherwise calldatasize must be zero.
   calldatasize          ;; [calldatasize, req_fee]
-  iszero                ;; [calldatasize == 0, req_fee]
-  iszero                ;; [calldatasize != 0, req_fee]
   jumpi @revert         ;; [req_fee]
 
   ;; This is the read path, where we return the current excess.
   ;; Reject any callvalue here to prevent lost funds.
   callvalue             ;; [value, req_fee]
-  iszero                ;; [value == 0, req_fee]
-  iszero                ;; [value != 0, req_fee]
   jumpi @revert         ;; [req_fee]
 
   ;; Return req_fee.

--- a/src/withdrawals/main.eas
+++ b/src/withdrawals/main.eas
@@ -70,7 +70,7 @@
   push MIN_FEE          ;; [min_fee, excess, update_fraction]
   #include "../common/fake_expo.eas"
 
-  ;; If calldatasize matches the expected input size, add the request.
+  ;; If calldatasize matches the expected input size, go to adding the request.
   calldatasize          ;; [calldatasize, req_fee]
   push INPUT_SIZE       ;; [INPUT_SIZE, calldatasize, req_fee]
   eq                    ;; [INPUT_SIZE == calldatasize, req_fee]
@@ -89,7 +89,7 @@
   iszero                ;; [value != 0, req_fee]
   jumpi @revert
 
-  ;; Load excess withdrawal requests and return the value.
+  ;; Return req_fee.
   push 0                ;; [0, req_fee]
   mstore                ;; []
   push 32               ;; [32]

--- a/src/withdrawals/main.eas
+++ b/src/withdrawals/main.eas
@@ -78,15 +78,11 @@
 
   ;; Otherwise calldatasize must be zero.
   calldatasize          ;; [calldatasize, req_fee]
-  iszero                ;; [calldatasize == 0, req_fee]
-  iszero                ;; [calldatasize != 0, req_fee]
   jumpi @revert         ;; [req_fee]
 
   ;; This is the read path, where we return the current fee.
   ;; Reject any callvalue here to prevent lost funds.
   callvalue             ;; [value, req_fee]
-  iszero                ;; [value == 0, req_fee]
-  iszero                ;; [value != 0, req_fee]
   jumpi @revert
 
   ;; Return req_fee.

--- a/src/withdrawals/main.eas
+++ b/src/withdrawals/main.eas
@@ -55,29 +55,6 @@
   ;; --------------------------------------------------------------------------
   ;; USER SUBROUTINE ----------------------------------------------------------
   ;; --------------------------------------------------------------------------
-  ;;
-  ;; Record new withdrawal request ~~
-  ;; This is the default code path. It will attempt to record a user's request
-  ;; so long as they pay the required fee.
-
-  ;; If calldatasize == 0, return the current excess requests.
-  calldatasize          ;; [calldatasize]
-  iszero                ;; [calldatasize == 0]
-  jumpi @read_excess
-
-  ;; Input data has the following layout:
-  ;;
-  ;;  +--------+--------+
-  ;;  | pubkey | amount |
-  ;;  +--------+--------+
-  ;;      48       8
-
-  ;; Verify the input is exactly 56 bytes.
-  calldatasize          ;; [calldatasize]
-  push INPUT_SIZE       ;; [INPUT_SIZE, calldatasize]
-  eq                    ;; [INPUT_SIZE == calldatasize]
-  iszero                ;; [INPUT_SIZE != calldatasize]
-  jumpi @revert         ;; []
 
   ;; Compute the fee using fake expo and the current excess withdrawal requests.
   push FEE_UPDATE_FRACTION
@@ -92,6 +69,41 @@
 
   push MIN_FEE          ;; [min_fee, excess, update_fraction]
   #include "../common/fake_expo.eas"
+
+  ;; If calldatasize matches the expected input size, add the request.
+  calldatasize          ;; [calldatasize, req_fee]
+  push INPUT_SIZE       ;; [INPUT_SIZE, calldatasize, req_fee]
+  eq                    ;; [INPUT_SIZE == calldatasize, req_fee]
+  jumpi @handle_input
+
+  ;; Otherwise calldatasize must be zero.
+  calldatasize          ;; [calldatasize, req_fee]
+  iszero                ;; [calldatasize == 0, req_fee]
+  iszero                ;; [calldatasize != 0, req_fee]
+  jumpi @revert         ;; [req_fee]
+
+  ;; This is the read path, where we return the current fee.
+  ;; Reject any callvalue here to prevent lost funds.
+  callvalue             ;; [value, req_fee]
+  iszero                ;; [value == 0, req_fee]
+  iszero                ;; [value != 0, req_fee]
+  jumpi @revert
+
+  ;; Load excess withdrawal requests and return the value.
+  push 0                ;; [0, req_fee]
+  mstore                ;; []
+  push 32               ;; [32]
+  push 0                ;; [0, 32]
+  return                ;; []
+
+handle_input:
+  ;; This is the write path. We expect the computed fee on the stack.
+  ;; Input data has the following layout:
+  ;;
+  ;;  +--------+--------+
+  ;;  | pubkey | amount |
+  ;;  +--------+--------+
+  ;;      48       8
 
   ;; Determine if the fee provided is enough to cover the withdrawal request fee.
   callvalue             ;; [callvalue, req_fee]
@@ -161,23 +173,6 @@
   sstore                ;; []
 
   stop
-
-read_excess:
-  ;; This is the read path, where we return the current excess.
-  ;; Reject any callvalue here to prevent lost funds.
-  callvalue             ;; [value]
-  iszero                ;; [value == 0]
-  iszero                ;; [value != 0]
-  jumpi @revert
-
-  ;; Load excess withdrawal requests and return the value.
-  push SLOT_EXCESS      ;; [excess_reqs_slot]
-  sload                 ;; [excess_reqs]
-  push 0                ;; [0, excess_reqs]
-  mstore                ;; []
-  push 32               ;; [32]
-  push 0                ;; [0, 32]
-  return                ;; []
 
 ;; ----------------------------------------------------------------------------
 ;; SYSTEM SUBROUTINE ----------------------------------------------------------

--- a/test/Test.sol
+++ b/test/Test.sol
@@ -50,8 +50,9 @@ abstract contract Test is StdTest {
   // system contract matches count.
   function assertExcess(uint256 count) internal {
     assertStorage(excess_slot, count, "unexpected excess requests");
+    uint256 expectedFee = computeFee(count);
     (, bytes memory data) = addr.call("");
-    assertEq(toFixed(data, 0, 32), count, "unexpected excess requests");
+    assertEq(uint256(bytes32(data)), expectedFee, "unexpected fee returned");
   }
 }
 


### PR DESCRIPTION
I'm proposing we change the contract to return the required fee instead of returning the excess requests count.
The contract now computes the fee first, and then goes on to check for calldata.

The reason is simple: the read operation is a part of the contract so that people can compute the exact required
fee that must be passed. The fee computation is not straightforward, using 'fake exponential' and some constants. Any wrapper contract would have to recompute the fee from the excess value in the same way as the system contract does. Returning the fee value directly makes the formula an implementation detail, and simplifies the wrapper:

```solidity
function addWithdrawal(bytes memory pubkey, uint64 amount) private {
    assert(pubkey.length == 48);

    // Read current fee from the contract.
    (bool readOK, bytes memory feeData) = WithdrawalsContract.call('');
    if (!readOK) {
        revert('reading fee failed');
    }
    uint256 fee = uint256(bytes32(feeData));

    // Add the request.
    (bool writeOK,) = WithdrawalsContract.call{value: fee}(abi.encodePacked(pubkey, amount));
    if (!writeOK) {
        revert('adding request failed');
    }
}
```

Note this partially undoes the changes in #30 where I moved the read operation below write. After staring at it for a while, it seems better to have the read path first, especially since it is now so small.