### PR TITLE
all: port to geas v0.2

### DIFF
--- a/src/beacon_root/main.eas
+++ b/src/beacon_root/main.eas
@@ -22,16 +22,17 @@
 ;; buflen to the timestamp's index in the first ring buffer. The sum will be
 ;; the storage slot in the second ring buffer where it is stored.
 
+#pragma target "cancun"
 
 ;; ----------------------------------------------------------------------------
 ;; MACROS ---------------------------------------------------------------------
 ;; ----------------------------------------------------------------------------
 
 ;; BUFLEN returns the HISTORY_BUFFER_LENGTH as defined in the EIP.
-#define BUFLEN 8191
+#define BUFLEN = 8191
 
 ;; SYSADDR is the address which calls the contract to submit a new root.
-#define SYSADDR 0xfffffffffffffffffffffffffffffffffffffffe
+#define SYSADDR = .address(0xfffffffffffffffffffffffffffffffffffffffe)
 
 ;; do_revert sets up and then executes a revert(0,0) operation.
 #define %do_revert() {
@@ -44,7 +45,6 @@
 ;; MACROS END -----------------------------------------------------------------
 ;; ----------------------------------------------------------------------------
 
-.start:
   ;; Protect the submit routine by verifying the caller is equal to
   ;; sysaddr().
   caller           ;; [caller]

--- a/src/consolidations/main.eas
+++ b/src/consolidations/main.eas
@@ -2,7 +2,7 @@
 ;;    ▐▌   █ █    █ ▝▚▄▟▌▀▄▄  ▄▄▄▄
 ;;    ▐▌█▀▀▀ ▀▀▀█ █      ▄▄▄▀ █ █ █
 ;;    ▐▌█▄▄▄ ▄▄▄█ █           █   █
-
+;;
 ;; This is an implementation of EIP-7251 style contract handling EL triggerred
 ;; consolidations. It leverages on the fee mechanism and the queue design of the
 ;; original EIP-7002 smart contract implementation. Therefore, the subroutines
@@ -11,35 +11,35 @@
 ;; The difference from the EIP-7002 smart contract is in input data, the size of
 ;; the queue item, target and max block parameters.
 
+#pragma target "prague"
+
 ;; ----------------------------------------------------------------------------
 ;; CONSTANTS ------------------------------------------------------------------
 ;; ----------------------------------------------------------------------------
 
-#define SYSTEM_ADDR 0xfffffffffffffffffffffffffffffffffffffffe
+#define SYSTEM_ADDR = .address(0xfffffffffffffffffffffffffffffffffffffffe)
 
-#define SLOT_EXCESS 0
-#define SLOT_COUNT 1
+#define SLOT_EXCESS = 0
+#define SLOT_COUNT = 1
 
-#define QUEUE_HEAD 2
-#define QUEUE_TAIL 3
-#define QUEUE_OFFSET 4
+#define QUEUE_HEAD = 2
+#define QUEUE_TAIL  = 3
+#define QUEUE_OFFSET = 4
 
+#define MIN_FEE = 1
+#define TARGET_PER_BLOCK = 1
+#define MAX_PER_BLOCK = 1
+#define FEE_UPDATE_FRACTION = 17
+#define EXCESS_INHIBITOR = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 
-#define MIN_FEE 1
-#define TARGET_PER_BLOCK 1
-#define MAX_PER_BLOCK 1
-#define FEE_UPDATE_FRACTION 17
-#define EXCESS_INHIBITOR 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-
-#define INPUT_SIZE 96    ;; the size of (source ++ target)
-#define RECORD_SIZE 116  ;; the size of (address ++ source ++ target)
-#define SLOTS_PER_ITEM 4 ;; (addr, src[0:32], src[32:48]+tgt[0:16], tgt[16:48])
+#define INPUT_SIZE = 96    ;; the size of (source ++ target)
+#define RECORD_SIZE = 116  ;; the size of (address ++ source ++ target)
+#define SLOTS_PER_ITEM = 4 ;; (addr, src[0:32], src[32:48]+tgt[0:16], tgt[16:48])
 
 ;; ----------------------------------------------------------------------------
 ;; PROGRAM START --------------------------------------------------------------
 ;; ----------------------------------------------------------------------------
 
-.start:
   ;; Protect the system subroutine by checking if the caller is the system
   ;; address.
   caller                ;; [caller]

--- a/src/execution_hash/main.eas
+++ b/src/execution_hash/main.eas
@@ -7,21 +7,22 @@
 ;; The contract implements a ring buffer to create bounded execution block hash
 ;; lookup. 
 
+#pragma target "prague"
+
 ;; ----------------------------------------------------------------------------
 ;; MACROS ---------------------------------------------------------------------
 ;; ----------------------------------------------------------------------------
 
 ;; BUFLEN returns the HISTORY_BUFFER_LENGTH as defined in the EIP.
-#define BUFLEN 8191
+#define BUFLEN = 8191
 
 ;; SYSADDR is the address which calls the contract to submit a new block hash.
-#define SYSADDR 0xfffffffffffffffffffffffffffffffffffffffe
+#define SYSADDR = .address(0xfffffffffffffffffffffffffffffffffffffffe)
 
 ;; ----------------------------------------------------------------------------
 ;; MACROS END -----------------------------------------------------------------
 ;; ----------------------------------------------------------------------------
 
-.start:
   ;; Protect the submit routine by verifying the caller is equal to
   ;; sysaddr().
   caller            ;; [caller]

--- a/src/withdrawals/main.eas
+++ b/src/withdrawals/main.eas
@@ -17,34 +17,35 @@
 ;; being processed by the beacon chain is the validity verified. The fee is used
 ;; to avoid spamming of the withdrawal requests queue.
 
+#pragma target "prague"
+
 ;; -----------------------------------------------------------------------------
 ;; CONSTANTS -------------------------------------------------------------------
 ;; -----------------------------------------------------------------------------
 
-#define SYSTEM_ADDR 0xfffffffffffffffffffffffffffffffffffffffe
+#define SYSTEM_ADDR = .address(0xfffffffffffffffffffffffffffffffffffffffe)
 
-#define SLOT_EXCESS 0
-#define SLOT_COUNT 1
+#define SLOT_EXCESS = 0
+#define SLOT_COUNT = 1
 
-#define QUEUE_HEAD 2
-#define QUEUE_TAIL 3
-#define QUEUE_OFFSET 4
+#define QUEUE_HEAD = 2
+#define QUEUE_TAIL = 3
+#define QUEUE_OFFSET = 4
 
-#define MIN_FEE 1
-#define TARGET_PER_BLOCK 2
-#define MAX_PER_BLOCK 16
-#define FEE_UPDATE_FRACTION 17
-#define EXCESS_INHIBITOR 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+#define MIN_FEE = 1
+#define TARGET_PER_BLOCK = 2
+#define MAX_PER_BLOCK = 16
+#define FEE_UPDATE_FRACTION = 17
+#define EXCESS_INHIBITOR = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 
-#define INPUT_SIZE 56   ;; the size of (pubkey ++ amount)
-#define RECORD_SIZE 76  ;; the size of (address ++ pubkey ++ amount)
-#define SLOTS_PER_ITEM 3 ;; (address, pubkey[0:32], pubkey[32:48] ++ amount)
+#define INPUT_SIZE = 56    ;; the size of (pubkey ++ amount)
+#define RECORD_SIZE = 76   ;; the size of (address ++ pubkey ++ amount)
+#define SLOTS_PER_ITEM = 3 ;; (address, pubkey[0:32], pubkey[32:48] ++ amount)
 
 ;; ----------------------------------------------------------------------------
 ;; PROGRAM START --------------------------------------------------------------
 ;; ----------------------------------------------------------------------------
 
-.start:
   ;; Protect the system subroutine by checking if the caller is the system
   ;; address.
   caller                ;; [caller]
@@ -422,7 +423,7 @@ revert:
 ;; ----------------------------------------------------------------------------
 
 ;; This defines a mask for accessing the top 16 bytes of a number.
-#define pk2_mask 0xffffffffffffffffffffffffffffffff00000000000000000000000000000000
+#define pk2_mask = 0xffffffffffffffffffffffffffffffff00000000000000000000000000000000
 
 ;; Helper for storing little-endian amount.
 #define %mstore_uint64_le() { ;; [offset, value]


### PR DESCRIPTION
This is just to remove some warnings with the new version. There are no differences in the bytecode output.

https://github.com/fjl/geas/releases/tag/v0.2.0