### PR TITLE
eip7251: Set MAX=2 for consolidations contract

### DIFF
--- a/src/consolidations/main.eas
+++ b/src/consolidations/main.eas
@@ -27,7 +27,7 @@
 
 #define MIN_FEE 1
 #define TARGET_PER_BLOCK 1
-#define MAX_PER_BLOCK 1
+#define MAX_PER_BLOCK 2
 #define FEE_UPDATE_FRACTION 17
 #define EXCESS_INHIBITOR 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 


### PR DESCRIPTION
Related to https://github.com/ethereum/consensus-specs/pull/4020

Sets `MAX_PER_BLOCK = 2` for consolidation smart contract and updates tests.

### ToDo
* [x] Update EIP-7251 once the change is merged, https://github.com/ethereum/EIPs/pull/9127