### PR TITLE
update buffer size

### DIFF
--- a/src/execution_hash/main.eas
+++ b/src/execution_hash/main.eas
@@ -14,7 +14,9 @@
 ;; ----------------------------------------------------------------------------
 
 ;; BUFLEN returns the HISTORY_BUFFER_LENGTH as defined in the EIP.
-#define BUFLEN = 8191
+;; was 8191, which is 8191*12 = 98292 seconds
+;; 98292 seconds is 98292 * 4 = 393168 L2 blocks
+#define BUFLEN = 393168 
 
 ;; SYSADDR is the address which calls the contract to submit a new block hash.
 #define SYSADDR = .address(0xfffffffffffffffffffffffffffffffffffffffe)


### PR DESCRIPTION
updated the ring buffer size to `393168`. assuming L2 block time of 250ms and L1 block time of 12s, then the amount of time that the buffer covers on L2 is equivalent to L1.

the following assembles the modified system contract bytecode that should exist at `0x0000F90827F1C53a10cb7A02335B175320002935`

```
geas src/execution_hash/main.eas
3373fffffffffffffffffffffffffffffffffffffffe14604857602036036044575f356001430381116044576205ffd0814303116044576205ffd09006545f5260205ff35b5f5ffd5b5f356205ffd060014303065500
```