### PR TITLE
all: update constructor codes for geas v0.3.0

### DIFF
--- a/src/beacon_root/ctor.eas
+++ b/src/beacon_root/ctor.eas
@@ -1,12 +1,10 @@
-;; Copy and return code.
-push @.end - @.start
-dup1
-push @.start
-push0
-codecopy
-push0
-return
+  ;; Copy and return code.
+  push len(code)     ; [len]
+  dup1               ; [len, len]
+  push @code         ; [codeOffset, len, len]
+  push 0             ; [dest, codeOffset, len, len]
+  codecopy           ; [len]
+  push 0             ; [ptr, len]
+  return             ; []
 
-.start:
-#assemble "main.eas"
-.end:
+#bytes code: assemble("main.eas")

--- a/src/consolidations/ctor.eas
+++ b/src/consolidations/ctor.eas
@@ -1,18 +1,16 @@
-;; Store 0xff..ff as a temporary excess value to avoid requests being queued
-;; before the fork.
-push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-push0
-sstore
+  ;; Store 0xff..ff as a temporary excess value to avoid requests being queued
+  ;; before the fork.
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  push 0             ; [slot, excess]
+  sstore             ; []
 
-;; Copy and return code.
-push @.end - @.start
-dup1
-push @.start
-push0
-codecopy
-push0
-return
+  ;; Copy and return code.
+  push len(code)     ; [len]
+  dup1               ; [len, len]
+  push @code         ; [codeOffset, len, len]
+  push 0             ; [dest, codeOffset, len, len]
+  codecopy           ; [len]
+  push 0             ; [ptr, len]
+  return             ; []
 
-.start:
-#assemble "main.eas"
-.end:
+#bytes code: assemble("main.eas")

--- a/src/consolidations/ctor.eas
+++ b/src/consolidations/ctor.eas
@@ -1,6 +1,6 @@
   ;; Store 0xff..ff as a temporary excess value to avoid requests being queued
   ;; before the fork.
-  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  push (1<<256)-1    ; [excess]
   push 0             ; [slot, excess]
   sstore             ; []
 

--- a/src/execution_hash/ctor.eas
+++ b/src/execution_hash/ctor.eas
@@ -1,12 +1,10 @@
-;; Copy and return code.
-push @.end - @.start
-dup1
-push @.start
-push0
-codecopy
-push0
-return
+  ;; Copy and return code.
+  push len(code)     ; [len]
+  dup1               ; [len, len]
+  push @code         ; [codeOffset, len, len]
+  push 0             ; [dest, codeOffset, len, len]
+  codecopy           ; [len]
+  push 0             ; [ptr, len]
+  return             ; []
 
-.start:
-#assemble "main.eas"
-.end:
+#bytes code: assemble("main.eas")

--- a/src/withdrawals/ctor.eas
+++ b/src/withdrawals/ctor.eas
@@ -1,18 +1,16 @@
-;; Store 0xff..ff as a temporary excess value to avoid requests being queued
-;; before the fork.
-push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-push0
-sstore
+  ;; Store 0xff..ff as a temporary excess value to avoid requests being queued
+  ;; before the fork.
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  push 0             ; [slot, excess]
+  sstore             ; []
 
-;; Copy and return code.
-push @.end - @.start
-dup1
-push @.start
-push0
-codecopy
-push0
-return
+  ;; Copy and return code.
+  push len(code)     ; [len]
+  dup1               ; [len, len]
+  push @code         ; [codeOffset, len, len]
+  push 0             ; [dest, codeOffset, len, len]
+  codecopy           ; [len]
+  push 0             ; [ptr, len]
+  return             ; []
 
-.start:
-#assemble "main.eas"
-.end:
+#bytes code: assemble("main.eas")

--- a/src/withdrawals/ctor.eas
+++ b/src/withdrawals/ctor.eas
@@ -1,6 +1,6 @@
   ;; Store 0xff..ff as a temporary excess value to avoid requests being queued
   ;; before the fork.
-  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  push (1<<256)-1    ; [excess]
   push 0             ; [slot, excess]
   sstore             ; []
 


### PR DESCRIPTION
This fixes warnings issued by geas v0.3.0 and also improves the constructor code a bit by adding stack comments. I have manually verified the bytecode is identical with this update. At some point we should probably hard-code the hashes somewhere to lock in the code as deployed on-chain.