### PR TITLE
all: reformat source code

### DIFF
--- a/src/beacon_root/ctor.eas
+++ b/src/beacon_root/ctor.eas
@@ -1,10 +1,10 @@
-  ;; Copy and return code.
-  push len(code)     ; [len]
-  dup1               ; [len, len]
-  push @code         ; [codeOffset, len, len]
-  push 0             ; [dest, codeOffset, len, len]
-  codecopy           ; [len]
-  push 0             ; [ptr, len]
-  return             ; []
+    ;; Copy and return code.
+    push len(code)     ; [len]
+    dup1               ; [len, len]
+    push @code         ; [codeOffset, len, len]
+    push 0             ; [dest, codeOffset, len, len]
+    codecopy           ; [len]
+    push 0             ; [ptr, len]
+    return             ; []
 
 #bytes code: assemble("main.eas")

--- a/src/beacon_root/main.eas
+++ b/src/beacon_root/main.eas
@@ -1,134 +1,134 @@
-;;    __ ___________  ____                     
-;;   / // /__  ( __ )( __ )____ __________ ___ 
-;;  / // /_ / / __  / __  / __ `/ ___/ __ `__ \
-;; /__  __// / /_/ / /_/ / /_/ (__  ) / / / / /
-;;   /_/  /_/\____/\____/\__,_/____/_/ /_/ /_/ 
-;;                                             
-;; This is an implementation of EIP-4788's predeploy contract. It implements
-;; two ring buffers to create bounded beacon root lookup. The first ring
-;; buffer is a timestamp % buflen -> timestamp mapping. This is used to ensure
-;; timestamp argument actually matches the stored root and isn't different
-;; dividend. The second ring buffer store the beacon root. It's also keyed by
-;; timestamp % buflen and the shifted right by buflen so the two don't overlap.
-;;
-;; The ring buffers can be visualized as follows:
-;;
-;;  buflen = 10
-;; |--------------|--------------|
-;; 0             10              20
-;;   timestamps     beacon roots
-;;
-;; To get the corresponding beacon root for a specific timestamp, simply add
-;; buflen to the timestamp's index in the first ring buffer. The sum will be
-;; the storage slot in the second ring buffer where it is stored.
+;;;    __ ___________  ____
+;;;   / // /__  ( __ )( __ )____ __________ ___
+;;;  / // /_ / / __  / __  / __ `/ ___/ __ `__ \
+;;; /__  __// / /_/ / /_/ / /_/ (__  ) / / / / /
+;;;   /_/  /_/\____/\____/\__,_/____/_/ /_/ /_/
+;;;
+;;; This is an implementation of EIP-4788's predeploy contract. It implements
+;;; two ring buffers to create bounded beacon root lookup. The first ring
+;;; buffer is a timestamp % buflen -> timestamp mapping. This is used to ensure
+;;; timestamp argument actually matches the stored root and isn't different
+;;; dividend. The second ring buffer store the beacon root. It's also keyed by
+;;; timestamp % buflen and the shifted right by buflen so the two don't overlap.
+;;;
+;;; The ring buffers can be visualized as follows:
+;;;
+;;;  buflen = 10
+;;; |--------------|--------------|
+;;; 0             10              20
+;;;   timestamps     beacon roots
+;;;
+;;; To get the corresponding beacon root for a specific timestamp, simply add
+;;; buflen to the timestamp's index in the first ring buffer. The sum will be
+;;; the storage slot in the second ring buffer where it is stored.
 
 #pragma target "cancun"
 
-;; ----------------------------------------------------------------------------
-;; MACROS ---------------------------------------------------------------------
-;; ----------------------------------------------------------------------------
+;;; ----------------------------------------------------------------------------
+;;; MACROS ---------------------------------------------------------------------
+;;; ----------------------------------------------------------------------------
 
-;; BUFLEN returns the HISTORY_BUFFER_LENGTH as defined in the EIP.
+;;; HISTORY_BUFFER_LENGTH as defined in the EIP.
 #define BUFLEN = 8191
 
-;; SYSADDR is the address which calls the contract to submit a new root.
+;;; SYSADDR is the address which calls the contract to submit a new root.
 #define SYSADDR = .address(0xfffffffffffffffffffffffffffffffffffffffe)
 
-;; do_revert sets up and then executes a revert(0,0) operation.
-#define %do_revert() {
-  push 0          ;; [0]
-  push 0          ;; [0, 0]
-  revert          ;; []
+;;; do_revert sets up and then executes a revert(0,0) operation.
+#define %do_revert {
+    push 0             ; [0]
+    push 0             ; [0, 0]
+    revert             ; []
 }
 
-;; ----------------------------------------------------------------------------
-;; MACROS END -----------------------------------------------------------------
-;; ----------------------------------------------------------------------------
+;;; ----------------------------------------------------------------------------
+;;; PROGRAM START --------------------------------------------------------------
+;;; ----------------------------------------------------------------------------
 
-  ;; Protect the submit routine by verifying the caller is equal to
-  ;; sysaddr().
-  caller           ;; [caller]
-  push SYSADDR     ;; [sysaddr, caller]
-  eq               ;; [sysaddr == caller]
-  jumpi @submit    ;; []
+    ;; Protect the submit routine by verifying the caller is equal to
+    ;; sysaddr().
+    caller             ; [caller]
+    push SYSADDR       ; [sysaddr, caller]
+    eq                 ; [sysaddr == caller]
+    jumpi @submit      ; []
 
-  ;; Fallthrough if addresses don't match -- this means the caller intends
-  ;; to read a root.
+    ;; Fallthrough if addresses don't match -- this means the caller intends
+    ;; to read a root.
 
-  ;; Check if calldata is equal to 32 bytes.
-  push 32          ;; [32]
-  calldatasize     ;; [calldatasize, 32]
-  eq               ;; [calldatasize == 32]
+    ;; Check if calldata is equal to 32 bytes.
+    push 32            ; [32]
+    calldatasize       ; [calldatasize, 32]
+    eq                 ; [calldatasize == 32]
 
-  ;; Jump to continue if length-check passed, otherwise revert.
-  jumpi @loadtime  ;; []
-  %do_revert()     ;; []
+    ;; Jump to continue if length-check passed, otherwise revert.
+    jumpi @loadtime    ; []
+    %do_revert         ; []
 
 loadtime:
-  ;; Load input timestamp.
-  push 0           ;; [0]
-  calldataload     ;; [input_timestamp]
-  dup1             ;; [input_timestamp, input_timestamp]
+    ;; Load input timestamp.
+    push 0             ; [0]
+    calldataload       ; [input_timestamp]
+    dup1               ; [input_timestamp, input_timestamp]
 
-  ;; Verify input timestamp is non-zero.
-  iszero           ;; [input_timestamp == 0, input_timestamp]
-  jumpi @throw     ;; [input_timestamp]
+    ;; Verify input timestamp is non-zero.
+    iszero             ; [input_timestamp == 0, input_timestamp]
+    jumpi @throw       ; [input_timestamp]
 
-  ;; Compute the timestamp index and load from storage.
-  push BUFLEN      ;; [buflen, input_timestamp]
-  dup2             ;; [input_timestamp, buflen, input_timestamp]
-  mod              ;; [time_index, input_timestamp]
-  swap1            ;; [input_timestamp, time_index]
-  dup2             ;; [time_index, input_timestamp, time_index]
-  sload            ;; [stored_timestamp, input_timestamp, time_index]
+    ;; Compute the timestamp index and load from storage.
+    push BUFLEN        ; [buflen, input_timestamp]
+    dup2               ; [input_timestamp, buflen, input_timestamp]
+    mod                ; [time_index, input_timestamp]
+    swap1              ; [input_timestamp, time_index]
+    dup2               ; [time_index, input_timestamp, time_index]
+    sload              ; [stored_timestamp, input_timestamp, time_index]
 
-  ;; Verify stored timestamp matches input timestamp. It's possible these
-  ;; don't match if the slot has been overwritten by the ring buffer or if
-  ;; the timestamp input wasn't a valid previous timestamp.
-  eq               ;; [stored_timestamp == input_timestamp, time_index]
-  jumpi @loadroot  ;; [time_index]
-  %do_revert()     ;; []
+    ;; Verify stored timestamp matches input timestamp. It's possible these
+    ;; don't match if the slot has been overwritten by the ring buffer or if
+    ;; the timestamp input wasn't a valid previous timestamp.
+    eq                 ; [stored_timestamp == input_timestamp, time_index]
+    jumpi @loadroot    ; [time_index]
+    %do_revert         ; []
 
 loadroot:
-  ;; Extend index to get root index.
-  push BUFLEN      ;; [buflen, time_index]
-  add              ;; [root_index]
-  sload            ;; [root]
+    ;; Extend index to get root index.
+    push BUFLEN        ; [buflen, time_index]
+    add                ; [root_index]
+    sload              ; [root]
 
-  ;; Write the retrieved root to memory so it can be returned.
-  push 0           ;; [0, root]
-  mstore           ;; []
+    ;; Write the retrieved root to memory so it can be returned.
+    push 0             ; [0, root]
+    mstore             ; []
 
-  ;; Return the root.
-  push 32          ;; [size]
-  push 0           ;; [offset, size]
-  return           ;; []
+    ;; Return the root.
+    push 32            ; [size]
+    push 0             ; [offset, size]
+    return             ; []
 
 throw:
-  ;; Reverts current execution with no return data.
-  %do_revert()
+    ;; Reverts current execution with no return data.
+    %do_revert
 
 submit:
-  ;; Calculate the index the timestamp should be stored at, e.g.
-  ;; time_index = (time % buflen).
-  push BUFLEN      ;; [buflen]
-  timestamp        ;; [time, buflen]
-  mod              ;; [time % buflen]
+    ;; Calculate the index the timestamp should be stored at, e.g.
+    ;; time_index = (time % buflen).
+    push BUFLEN        ; [buflen]
+    timestamp          ; [time, buflen]
+    mod                ; [time % buflen]
 
-  ;; Write timestamp into storage slot at time_index.
-  timestamp        ;; [time, time_index]
-  dup2             ;; [time_index, time, time_index]
-  sstore           ;; [time_index]
+    ;; Write timestamp into storage slot at time_index.
+    timestamp          ; [time, time_index]
+    dup2               ; [time_index, time, time_index]
+    sstore             ; [time_index]
 
-  ;; Get root from calldata and write into root_index. No validation is
-  ;; done on the input root. Becuase the routine is protected by a caller
-  ;; check against sysaddr(), it's okay to assume the value is correctly
-  ;; given.
-  push 0           ;; [0, time_index]
-  calldataload     ;; [root, time_index]
-  swap1            ;; [time_index, root]
-  push BUFLEN      ;; [buflen, time_index, root]
-  add              ;; [root_index, root]
-  sstore           ;; []
+    ;; Get root from calldata and write into root_index. No validation is
+    ;; done on the input root. Becuase the routine is protected by a caller
+    ;; check against sysaddr(), it's okay to assume the value is correctly
+    ;; given.
+    push 0             ; [0, time_index]
+    calldataload       ; [root, time_index]
+    swap1              ; [time_index, root]
+    push BUFLEN        ; [buflen, time_index, root]
+    add                ; [root_index, root]
+    sstore             ; []
 
-  stop             ;; []
+    stop               ; []

--- a/src/common/fake_expo.eas
+++ b/src/common/fake_expo.eas
@@ -1,51 +1,50 @@
-;; fake exponentiation
-;; input stack = [factor, numerator, denominator]
+;;; fake exponentiation
 
-dup3        ;; [denom, factor, numer, denom]
-mul         ;; [accum, numer, denom]
-push 1      ;; [i, accum, numer, denom]
-swap1       ;; [accum, i, numer, denom]
-push 0      ;; [output, accum, i, numer, denom]
+                       ; [factor, numer, denom]
+    dup3               ; [denom, factor, numer, denom]
+    mul                ; [accum, numer, denom]
+    push 1             ; [i, accum, numer, denom]
+    swap1              ; [accum, i, numer, denom]
+    push 0             ; [output, accum, i, numer, denom]
 
 loop:
+    ;; while accum > 0
+    push 0             ; [0, output, accum, i, numer, denom]
+    dup3               ; [accum, 0, output, accum, i, numer, denom]
+    gt                 ; [accum > 0, output, accum, i, numer, denom]
+    iszero             ; [!(accum > 0), output, accum, i, numer, denom]
+    jumpi @done        ; [output, accum, i, numer, denom]
 
-;; while accum > 0
-push 0      ;; [0, output, accum, i, numer, denom]
-dup3        ;; [accum, 0, output, accum, i, numer, denom]
-gt          ;; [accum > 0, output, accum, i, numer, denom]
-iszero      ;; [!(accum > 0), output, accum, i, numer, denom]
-jumpi @done ;; [output, accum, i, numer, denom]
+    ;; output += accum
+    dup2               ; [accum, output, accum, i, numer, denom]
+    add                ; [output, accum, i, numer, denom]
 
-;; output += accum
-dup2        ;; [accum, output, accum, i, numer, denom]
-add         ;; [output, accum, i, numer, denom]
+    ;; accum = (numer_accum * numer) // (denom * i)
+    swap1              ; [accum, output, i, numer, denom]
+    dup4               ; [numer, accum, output, i, numer, denom]
+    mul                ; [accum*numer, output, i, numer, denom]
 
-;; accum = (numer_accum * numer) // (denom * i)
-swap1       ;; [accum, output, i, numer, denom]
-dup4        ;; [numer, accum, output, i, numer, denom]
-mul         ;; [accum*numer, output, i, numer, denom]
+    dup5               ; [denom, accum*numer, output, i, numer, denom]
+    dup4               ; [i, denom, accum*numer, output, i, numer, denom]
+    mul                ; [i*denom, accum*numer, output, i, numer, denom]
+    swap1              ; [accum*numer, i*denom, output, i, numer, denom]
+    div                ; [accum, output, i, numer, denom]
 
-dup5        ;; [denom, accum*numer, output, i, numer, denom]
-dup4        ;; [i, denom, accum*numer, output, i, numer, denom]
-mul         ;; [i*denom, accum*numer, output, i, numer, denom]
-swap1       ;; [accum*numer, i*denom, output, i, numer, denom]
-div         ;; [accum, output, i, numer, denom]
-
-swap2       ;; [i, output, accum, numer, denom]
-push 1      ;; [1, i, output, accum, numer, denom]
-add         ;; [i, output, accum, numer, denom]
-swap2       ;; [accum, output, i, numer, denom]
-swap1       ;; [output, accum, i, numer, denom]
-jump @loop
+    swap2              ; [i, output, accum, numer, denom]
+    push 1             ; [1, i, output, accum, numer, denom]
+    add                ; [i, output, accum, numer, denom]
+    swap2              ; [accum, output, i, numer, denom]
+    swap1              ; [output, accum, i, numer, denom]
+    jump @loop
 
 done:
-swap1       ;; [accum, output, i, numer, denom]
-swap4       ;; [denom, output, i, numer, accum]
-swap1       ;; [output, denom, i, numer, accum]
-div         ;; [output / denom, i , numer, accum]
+    swap1              ; [accum, output, i, numer, denom]
+    swap4              ; [denom, output, i, numer, accum]
+    swap1              ; [output, denom, i, numer, accum]
+    div                ; [output / denom, i , numer, accum]
 
-;; clean up stack
-swap3       ;; [accum, i, numer, output/denom]
-pop         ;; [i, numer, output/denom]
-pop         ;; [numer, output/denom]
-pop         ;; [output/denom]
+    ;; clean up stack
+    swap3              ; [accum, i, numer, output/denom]
+    pop                ; [i, numer, output/denom]
+    pop                ; [numer, output/denom]
+    pop                ; [output/denom]

--- a/src/common/fake_expo_test.eas
+++ b/src/common/fake_expo_test.eas
@@ -1,42 +1,40 @@
-;; push calldata words onto stack
-;;;;
+;;; fake_expo wrapper for testing,
+;;; takes input from calldata, returns result to caller
 
-;; get word count for input
-push1 32      ;; [32]
-calldatasize  ;; [size, 32]
-div           ;; [words]
-push1 1       ;; [1, words]
-swap1         ;; [words, 1]
-sub           ;; [words-1]
+    ;; get word count for input
+    push1 32           ; [32]
+    calldatasize       ; [size, 32]
+    div                ; [words]
+    push1 1            ; [1, words]
+    swap1              ; [words, 1]
+    sub                ; [words-1]
 
-;; run loop
 loop:
+    ;; bound check - wait until overflow to quit
+    dup1               ; [i, i]
+    push32 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    eq                 ; [i == 2**256, i]
+    jumpi @end         ; [i]
 
-;; bound check - wait until overflow to quit
-dup1          ;; [i, i]
-push32 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-eq            ;; [i == 2**256, i]
-jumpi @end    ;; [i]
-
-;; perform load
-dup1          ;; [i, i]
-push1 32      ;; [32, i, i]
-mul           ;; [i*32, i]
-calldataload  ;; [x_i, i]
-swap1         ;; [i, x_i]
-push1 1       ;; [1, i, x_i]
-swap1         ;; [i, 1, x_i]
-sub           ;; [i--, words, x_i]
-jump @loop
+    ;; perform load
+    dup1               ; [i, i]
+    push1 32           ; [32, i, i]
+    mul                ; [i*32, i]
+    calldataload       ; [x_i, i]
+    swap1              ; [i, x_i]
+    push1 1            ; [1, i, x_i]
+    swap1              ; [i, 1, x_i]
+    sub                ; [i--, words, x_i]
+    jump @loop
 
 end:
-pop           ;; []
+    pop                ; []
 
 #include "fake_expo.eas"
 
-;; write result to memory and return it
-push0         ;; [0, expo]
-mstore        ;; []
-push1 32      ;; [32]
-push0         ;; [0, 32]
-return
+    ;; write result to memory and return it
+    push0              ; [0, expo]
+    mstore             ; []
+    push1 32           ; [32]
+    push0              ; [0, 32]
+    return

--- a/src/consolidations/ctor.eas
+++ b/src/consolidations/ctor.eas
@@ -1,16 +1,16 @@
-  ;; Store 0xff..ff as a temporary excess value to avoid requests being queued
-  ;; before the fork.
-  push (1<<256)-1    ; [excess]
-  push 0             ; [slot, excess]
-  sstore             ; []
+    ;; Store 0xff..ff as a temporary excess value to avoid requests being queued
+    ;; before the fork.
+    push (1 << 256) - 1  ; [excess]
+    push 0               ; [slot, excess]
+    sstore               ; []
 
-  ;; Copy and return code.
-  push len(code)     ; [len]
-  dup1               ; [len, len]
-  push @code         ; [codeOffset, len, len]
-  push 0             ; [dest, codeOffset, len, len]
-  codecopy           ; [len]
-  push 0             ; [ptr, len]
-  return             ; []
+    ;; Copy and return code.
+    push len(code)       ; [len]
+    dup1                 ; [len, len]
+    push @code           ; [codeOffset, len, len]
+    push 0               ; [dest, codeOffset, len, len]
+    codecopy             ; [len]
+    push 0               ; [ptr, len]
+    return               ; []
 
 #bytes code: assemble("main.eas")

--- a/src/consolidations/main.eas
+++ b/src/consolidations/main.eas
@@ -1,21 +1,21 @@
-;; ▗▄▄▄▖▄▄▄▄ ▄▄▄▄ ▄ ▗▞▀▜▌ ▄▄▄
-;;    ▐▌   █ █    █ ▝▚▄▟▌▀▄▄  ▄▄▄▄
-;;    ▐▌█▀▀▀ ▀▀▀█ █      ▄▄▄▀ █ █ █
-;;    ▐▌█▄▄▄ ▄▄▄█ █           █   █
-;;
-;; This is an implementation of EIP-7251 style contract handling EL triggerred
-;; consolidations. It leverages on the fee mechanism and the queue design of the
-;; original EIP-7002 smart contract implementation. Therefore, the subroutines
-;; logic of the original smart contract remains.
-;;
-;; The difference from the EIP-7002 smart contract is in input data, the size of
-;; the queue item, target and max block parameters.
+;;; ▗▄▄▄▖▄▄▄▄ ▄▄▄▄ ▄ ▗▞▀▜▌ ▄▄▄
+;;;    ▐▌   █ █    █ ▝▚▄▟▌▀▄▄  ▄▄▄▄
+;;;    ▐▌█▀▀▀ ▀▀▀█ █      ▄▄▄▀ █ █ █
+;;;    ▐▌█▄▄▄ ▄▄▄█ █           █   █
+;;;
+;;; This is an implementation of EIP-7251 style contract handling EL triggerred
+;;; consolidations. It leverages on the fee mechanism and the queue design of the
+;;; original EIP-7002 smart contract implementation. Therefore, the subroutines
+;;; logic of the original smart contract remains.
+;;;
+;;; The difference from the EIP-7002 smart contract is in input data, the size of
+;;; the queue item, target and max block parameters.
 
 #pragma target "prague"
 
-;; ----------------------------------------------------------------------------
-;; CONSTANTS ------------------------------------------------------------------
-;; ----------------------------------------------------------------------------
+;;; ----------------------------------------------------------------------------
+;;; CONSTANTS ------------------------------------------------------------------
+;;; ----------------------------------------------------------------------------
 
 #define SYSTEM_ADDR = .address(0xfffffffffffffffffffffffffffffffffffffffe)
 
@@ -23,7 +23,7 @@
 #define SLOT_COUNT = 1
 
 #define QUEUE_HEAD = 2
-#define QUEUE_TAIL  = 3
+#define QUEUE_TAIL = 3
 #define QUEUE_OFFSET = 4
 
 #define MIN_FEE = 1
@@ -32,390 +32,390 @@
 #define FEE_UPDATE_FRACTION = 17
 #define EXCESS_INHIBITOR = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 
-#define INPUT_SIZE = 96    ;; the size of (source ++ target)
-#define RECORD_SIZE = 116  ;; the size of (address ++ source ++ target)
-#define SLOTS_PER_ITEM = 4 ;; (addr, src[0:32], src[32:48]+tgt[0:16], tgt[16:48])
+#define INPUT_SIZE = 96    ; the size of (source ++ target)
+#define RECORD_SIZE = 116  ; the size of (address ++ source ++ target)
+#define SLOTS_PER_ITEM = 4 ; (addr, src[0:32], src[32:48]+tgt[0:16], tgt[16:48])
 
-;; ----------------------------------------------------------------------------
-;; PROGRAM START --------------------------------------------------------------
-;; ----------------------------------------------------------------------------
+;;; ----------------------------------------------------------------------------
+;;; PROGRAM START --------------------------------------------------------------
+;;; ----------------------------------------------------------------------------
 
-  ;; Protect the system subroutine by checking if the caller is the system
-  ;; address.
-  caller                ;; [caller]
-  push SYSTEM_ADDR      ;; [sysaddr, caller]
-  eq                    ;; [sysaddr == caller]
-  jumpi @read_requests  ;; []
+    ;; Protect the system subroutine by checking if the caller is the system
+    ;; address.
+    caller                 ; [caller]
+    push SYSTEM_ADDR       ; [sysaddr, caller]
+    eq                     ; [sysaddr == caller]
+    jumpi @read_requests   ; []
 
-  ;; --------------------------------------------------------------------------
-  ;; USER SUBROUTINE ----------------------------------------------------------
-  ;; --------------------------------------------------------------------------
+;;; --------------------------------------------------------------------------
+;;; USER SUBROUTINE ----------------------------------------------------------
+;;; --------------------------------------------------------------------------
 
-  ;; Compute the fee using fake expo and the current excess requests.
-  push FEE_UPDATE_FRACTION
-  push SLOT_EXCESS      ;; [excess_slot, update_fraction]
-  sload                 ;; [excess, update_fraction]
+    ;; Compute the fee using fake expo and the current excess requests.
+    push FEE_UPDATE_FRACTION
+    push SLOT_EXCESS       ; [excess_slot, update_fraction]
+    sload                  ; [excess, update_fraction]
 
-  ;; Check if the pre-fork inhibitor is still active, revert if so.
-  dup1                  ;; [excess, excess, update_fraction]
-  push EXCESS_INHIBITOR ;; [inhibitor, excess, excess, update_fraction]
-  eq                    ;; [inhibitor == excess, excess, update_fraction]
-  jumpi @revert         ;; [excess, update_fraction]
+    ;; Check if the pre-fork inhibitor is still active, revert if so.
+    dup1                   ; [excess, excess, update_fraction]
+    push EXCESS_INHIBITOR  ; [inhibitor, excess, excess, update_fraction]
+    eq                     ; [inhibitor == excess, excess, update_fraction]
+    jumpi @revert          ; [excess, update_fraction]
 
-  push MIN_FEE          ;; [min_fee, excess, update_fraction]
-  #include "../common/fake_expo.eas"
+    push MIN_FEE           ; [min_fee, excess, update_fraction]
+#include "../common/fake_expo.eas"
 
-  ;; If calldatasize matches the expected input size, go to adding the request.
-  calldatasize          ;; [calldatasize, req_fee]
-  push INPUT_SIZE       ;; [INPUT_SIZE, calldatasize, req_fee]
-  eq                    ;; [INPUT_SIZE == calldatasize, req_fee]
-  jumpi @handle_input   ;; [req_fee]
+    ;; If calldatasize matches the expected input size, go to adding the request.
+    calldatasize           ; [calldatasize, req_fee]
+    push INPUT_SIZE        ; [INPUT_SIZE, calldatasize, req_fee]
+    eq                     ; [INPUT_SIZE == calldatasize, req_fee]
+    jumpi @handle_input    ; [req_fee]
 
-  ;; Otherwise calldatasize must be zero.
-  calldatasize          ;; [calldatasize, req_fee]
-  jumpi @revert         ;; [req_fee]
+    ;; Otherwise calldatasize must be zero.
+    calldatasize           ; [calldatasize, req_fee]
+    jumpi @revert          ; [req_fee]
 
-  ;; This is the read path, where we return the current excess.
-  ;; Reject any callvalue here to prevent lost funds.
-  callvalue             ;; [value, req_fee]
-  jumpi @revert         ;; [req_fee]
+    ;; This is the read path, where we return the current excess.
+    ;; Reject any callvalue here to prevent lost funds.
+    callvalue              ; [value, req_fee]
+    jumpi @revert          ; [req_fee]
 
-  ;; Return req_fee.
-  push 0                ;; [0, req_fee]
-  mstore                ;; []
-  push 32               ;; [32]
-  push 0                ;; [0, 32]
-  return                ;; []
+    ;; Return req_fee.
+    push 0                 ; [0, req_fee]
+    mstore                 ; []
+    push 32                ; [32]
+    push 0                 ; [0, 32]
+    return                 ; []
 
 handle_input:
-  ;; This is the write path. We expect the computed fee on the stack.
-  ;; Input data has the following layout:
-  ;;
-  ;;  +--------+--------+
-  ;;  | source | target |
-  ;;  +--------+--------+
-  ;;      48       48
+    ;; This is the write path. We expect the computed fee on the stack.
+    ;; Input data has the following layout:
+    ;;
+    ;;  +--------+--------+
+    ;;  | source | target |
+    ;;  +--------+--------+
+    ;;      48       48
 
-  ;; Determine if the fee provided is enough to cover the request fee.
-  callvalue             ;; [callvalue, req_fee]
-  lt                    ;; [callvalue < req_fee]
-  jumpi @revert         ;; []
+    ;; Determine if the fee provided is enough to cover the request fee.
+    callvalue              ; [callvalue, req_fee]
+    lt                     ; [callvalue < req_fee]
+    jumpi @revert          ; []
 
-  ;; The request can pay, increment request count.
-  push SLOT_COUNT
-  sload                 ;; [req_count]
-  push 1                ;; [1, req_count]
-  add                   ;; [req_count+1]
-  push SLOT_COUNT
-  sstore                ;; []
+    ;; The request can pay, increment request count.
+    push SLOT_COUNT
+    sload                  ; [req_count]
+    push 1                 ; [1, req_count]
+    add                    ; [req_count+1]
+    push SLOT_COUNT
+    sstore                 ; []
 
-  ;; Now insert request into queue. First, compute the base storage slot
-  push QUEUE_TAIL       ;; [tail_idx_slot]
-  sload                 ;; [tail_idx]
-  dup1                  ;; [tail_idx, tail_idx]
-  push SLOTS_PER_ITEM   ;; [slots, tail_idx, tail_idx]
-  mul                   ;; [slots*tail_idx, tail_idx]
-  push QUEUE_OFFSET
-  add                   ;; [slot, tail_idx]
+    ;; Now insert request into queue. First, compute the base storage slot
+    push QUEUE_TAIL        ; [tail_idx_slot]
+    sload                  ; [tail_idx]
+    dup1                   ; [tail_idx, tail_idx]
+    push SLOTS_PER_ITEM    ; [slots, tail_idx, tail_idx]
+    mul                    ; [slots*tail_idx, tail_idx]
+    push QUEUE_OFFSET
+    add                    ; [slot, tail_idx]
 
-  ;; Write address to queue.
-  caller                ;; [caller, slot, ..]
-  dup2                  ;; [slot, caller, slot, ..]
-  sstore                ;; [slot, ..]
+    ;; Write address to queue.
+    caller                 ; [caller, slot, ..]
+    dup2                   ; [slot, caller, slot, ..]
+    sstore                 ; [slot, ..]
 
-  push 1                ;; [1, slot, ..]
-  add                   ;; [slot, ..]
+    push 1                 ; [1, slot, ..]
+    add                    ; [slot, ..]
 
-  ;; Store source[0:32] to queue.
-  push 0                ;; [0, slot, ..]
-  calldataload          ;; [source[0:32], slot, ..]
-  dup2                  ;; [slot, source[0:32], slot, ..]
-  sstore                ;; [slot, ..]
+    ;; Store source[0:32] to queue.
+    push 0                 ; [0, slot, ..]
+    calldataload           ; [source[0:32], slot, ..]
+    dup2                   ; [slot, source[0:32], slot, ..]
+    sstore                 ; [slot, ..]
 
-  push 1                ;; [1, slot, ..]
-  add                   ;; [slot, ..]
+    push 1                 ; [1, slot, ..]
+    add                    ; [slot, ..]
 
-  ;; Store source[32:48] ++ target[0:16] to queue.
-  push 32               ;; [32, slot, ..]
-  calldataload          ;; [source[32:48] ++ target[0:16], slot, ..]
-  dup2                  ;; [slot, source[32:48] ++ target[0:16], slot, ..]
-  sstore                ;; [slot, ..]
+    ;; Store source[32:48] ++ target[0:16] to queue.
+    push 32                ; [32, slot, ..]
+    calldataload           ; [source[32:48] ++ target[0:16], slot, ..]
+    dup2                   ; [slot, source[32:48] ++ target[0:16], slot, ..]
+    sstore                 ; [slot, ..]
 
-  push 1                ;; [1, slot, ..]
-  add                   ;; [slot, ..]
+    push 1                 ; [1, slot, ..]
+    add                    ; [slot, ..]
 
-  ;; Store target[16:48] to queue.
-  push 64               ;; [64, slot, ..]
-  calldataload          ;; [target[16:48], slot, ..]
-  swap1                 ;; [slot, target[16:48], ..]
-  sstore                ;; [..]
+    ;; Store target[16:48] to queue.
+    push 64                ; [64, slot, ..]
+    calldataload           ; [target[16:48], slot, ..]
+    swap1                  ; [slot, target[16:48], ..]
+    sstore                 ; [..]
 
+    ;; Assemble log data.
+    caller                 ; [caller, ..]
+    push 96                ; [96, caller, ..]
+    shl                    ; [caller, ..]
+    push 0                 ; [0, caller, ..]
+    mstore                 ; [..]
+    push INPUT_SIZE        ; [size, ..]
+    push 0                 ; [ost, size, ..]
+    push 20                ; [dest, ost, size, ..]
+    calldatacopy           ; [..]
 
-  ;; Assemble log data.
-  caller                ;; [caller, ..]
-  push 96               ;; [96, caller, ..]
-  shl                   ;; [caller, ..]
-  push 0                ;; [0, caller, ..]
-  mstore                ;; [..]
-  push INPUT_SIZE       ;; [size, ..]
-  push 0                ;; [ost, size, ..]
-  push 20               ;; [dest, ost, size, ..]
-  calldatacopy          ;; [..]
+    ;; Log record.
+    push RECORD_SIZE       ; [size, ..]
+    push 0                 ; [idx, size, ..]
+    log0                   ; [..]
 
-  ;; Log record.
-  push RECORD_SIZE      ;; [size, ..]
-  push 0                ;; [idx, size, ..]
-  log0                  ;; [..]
+    ;; Increment queue tail over last and write to storage.
+    push 1                 ; [1, tail_idx]
+    add                    ; [tail_idx+1]
+    push QUEUE_TAIL        ; [tail_idx_slot]
+    sstore                 ; []
 
-  ;; Increment queue tail over last and write to storage.
-  push 1                ;; [1, tail_idx]
-  add                   ;; [tail_idx+1]
-  push QUEUE_TAIL       ;; [tail_idx_slot]
-  sstore                ;; []
+    stop
 
-  stop
+;;; ----------------------------------------------------------------------------
+;;; SYSTEM SUBROUTINE ----------------------------------------------------------
+;;; ----------------------------------------------------------------------------
+;;;
+;;; Pop request from queue, update fee accumulator ~~ This is the logic executed
+;;; by the protocol each block. It reads as many requests as available from the
+;;; queue, until the max request per block is reached. The requests are returned
+;;; as a contiguous array of bytes with each record being exactly RECORD_SIZE
+;;; bytes.
+;;;
+;;;  Consolidation request record:
+;;;
+;;;  +------+--------+--------+
+;;;  | addr | source | target |
+;;;  +------+--------+--------+
+;;;     20      48       48
+;;;
+;;; Because the requests are stored across SLOTS_PER_ITEM storage slots, there is
+;;; some shuffling to align the data.
+;;;
+;;; After reading the requests, they are removed from the queue by modifying the
+;;; queue's head index. The excess requests accumulator is updated so that the
+;;; new cost of submitting a request is reflected. Finally, the request count is
+;;; reset.
 
-;; ----------------------------------------------------------------------------
-;; SYSTEM SUBROUTINE ----------------------------------------------------------
-;; ----------------------------------------------------------------------------
-;;
-;; Pop request from queue, update fee accumulator ~~ This is the logic executed
-;; by the protocol each block. It reads as many requests as available from the
-;; queue, until the max request per block is reached. The requests are returned
-;; as a contiguous array of bytes with each record being exactly RECORD_SIZE
-;; bytes.
-;;
-;;  Consolidation request record:
-;;
-;;  +------+--------+--------+
-;;  | addr | source | target |
-;;  +------+--------+--------+
-;;     20      48       48
-;;
-;; Because the requests are stored across SLOTS_PER_ITEM storage slots, there is
-;; some shuffling to align the data.
-;;
-;; After reading the requests, they are removed from the queue by modifying the
-;; queue's head index. The excess requests accumulator is updated so that the
-;; new cost of submitting a request is reflected. Finally, the request count is
-;; reset.
 read_requests:
-  ;; Determine the size of the queue by calculating tail - head.
-  push QUEUE_TAIL       ;; [tail_idx_slot]
-  sload                 ;; [tail_idx]
-  push QUEUE_HEAD       ;; [head_idx_slot, tail_idx]
-  sload                 ;; [head_idx, tail_idx]
+    ;; Determine the size of the queue by calculating tail - head.
+    push QUEUE_TAIL        ; [tail_idx_slot]
+    sload                  ; [tail_idx]
+    push QUEUE_HEAD        ; [head_idx_slot, tail_idx]
+    sload                  ; [head_idx, tail_idx]
 
-  ;; Now compute the count.
-  dup1                  ;; [head_idx, head_idx, tail_idx]
-  dup3                  ;; [tail_idx, head_idx, head_idx, tail_idx]
-  sub                   ;; [count, head_idx, tail_idx]
+    ;; Now compute the count.
+    dup1                   ; [head_idx, head_idx, tail_idx]
+    dup3                   ; [tail_idx, head_idx, head_idx, tail_idx]
+    sub                    ; [count, head_idx, tail_idx]
 
-  ;; Determine if count is greater than the max requests.
-  dup1                  ;; [count, count, head_idx, tail_idx]
-  push MAX_PER_BLOCK    ;; [reqs_per_block, count, count, head_idx, tail_idx]
-  gt                    ;; [reqs_per_block > count, count, head_idx, tail_idx]
-  jumpi @begin_loop     ;; [count, head_idx, tail_idx]
+    ;; Determine if count is greater than the max requests.
+    dup1                   ; [count, count, head_idx, tail_idx]
+    push MAX_PER_BLOCK     ; [reqs_per_block, count, count, head_idx, tail_idx]
+    gt                     ; [reqs_per_block > count, count, head_idx, tail_idx]
+    jumpi @begin_loop      ; [count, head_idx, tail_idx]
 
-  ;; Discard count, use the max requests per block.
-  pop                   ;; [head_idx, tail_idx]
-  push MAX_PER_BLOCK    ;; [count, head_idx, tail_idx]
+    ;; Discard count, use the max requests per block.
+    pop                    ; [head_idx, tail_idx]
+    push MAX_PER_BLOCK     ; [count, head_idx, tail_idx]
 
 begin_loop:
-  push 0                ;; [i, count, head_idx, tail_idx]
+    push 0                 ; [i, count, head_idx, tail_idx]
 
 accum_loop:
-  ;; This loop will read each request and byte bang it into a RECORD_SIZE byte chunk.
+    ;; This loop will read each request and byte bang it into a RECORD_SIZE byte chunk.
 
-  ;; Bounds check, ensure i < count.
-  dup2                  ;; [count, i, count, head_idx, tail_idx]
-  dup2                  ;; [i, count, i, count, head_idx, tail_idx]
-  eq                    ;; [i == count, i, count, head_idx, tail_idx]
-  jumpi @update_head    ;; [i, count, head_idx, tail_idx]
+    ;; Bounds check, ensure i < count.
+    dup2                   ; [count, i, count, head_idx, tail_idx]
+    dup2                   ; [i, count, i, count, head_idx, tail_idx]
+    eq                     ; [i == count, i, count, head_idx, tail_idx]
+    jumpi @update_head     ; [i, count, head_idx, tail_idx]
 
-  ;; Determine the storage slot of the address for this iteration. This value is
-  ;; also the base for the other storage slots containing the source and target
-  ;; public keys. The base slot will be (queue_offset + (queue_head + i)*4).
-  dup3                  ;; [head_idx, i, ..]
-  dup2                  ;; [i, head_idx, i, ..]
-  add                   ;; [i+head_idx, i, ..]
-  push SLOTS_PER_ITEM   ;; [4, i+head_idx, i, ..]
-  mul                   ;; [4*(i+head_idx), i, ..]
-  push QUEUE_OFFSET     ;; [offset, 4*(i+head_idx), i, ..]
-  add                   ;; [slotbase, i, ..]
+    ;; Determine the storage slot of the address for this iteration. This value is
+    ;; also the base for the other storage slots containing the source and target
+    ;; public keys. The base slot will be (queue_offset + (queue_head + i)*4).
+    dup3                   ; [head_idx, i, ..]
+    dup2                   ; [i, head_idx, i, ..]
+    add                    ; [i+head_idx, i, ..]
+    push SLOTS_PER_ITEM    ; [4, i+head_idx, i, ..]
+    mul                    ; [4*(i+head_idx), i, ..]
+    push QUEUE_OFFSET      ; [offset, 4*(i+head_idx), i, ..]
+    add                    ; [slotbase, i, ..]
 
-  ;; Write values to memory flat and contiguously. This requires combining the
-  ;; four storage elements (addr, spk1, spk2_tpk1, tpk2) so there is no padding.
-  ;;
-  ;; The slots have the following layout:
-  ;;
-  ;; 0: addr
-  ;;  0x00 | 00 00 00 00 00 00 00 00 00 00 00 00 aa aa aa aa
-  ;;  0x10 | aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa
-  ;;
-  ;; 1: source[0:32] -> spk1
-  ;;  0x00 | bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb
-  ;;  0x10 | bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb
-  ;;
-  ;; 2: source[32:48] ++ target[0:16] -> spk2_tpk1
-  ;;  0x00 | bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb
-  ;;  0x10 | cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc
-  ;;
-  ;; 3: target[16:48] -> tpk2
-  ;;  0x20 | cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc
-  ;;  0x30 | cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc
+    ;; Write values to memory flat and contiguously. This requires combining the
+    ;; four storage elements (addr, spk1, spk2_tpk1, tpk2) so there is no padding.
+    ;;
+    ;; The slots have the following layout:
+    ;;
+    ;; 0: addr
+    ;;  0x00 | 00 00 00 00 00 00 00 00 00 00 00 00 aa aa aa aa
+    ;;  0x10 | aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa
+    ;;
+    ;; 1: source[0:32] -> spk1
+    ;;  0x00 | bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb
+    ;;  0x10 | bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb
+    ;;
+    ;; 2: source[32:48] ++ target[0:16] -> spk2_tpk1
+    ;;  0x00 | bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb
+    ;;  0x10 | cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc
+    ;;
+    ;; 3: target[16:48] -> tpk2
+    ;;  0x20 | cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc
+    ;;  0x30 | cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc
 
-  ;; Compute the output offset = i*RECORD_SIZE.
-  dup2                  ;; [i, slotbase, i, ..]
-  push RECORD_SIZE      ;; [size, i, slotbase, i, ..]
-  mul                   ;; [offset=size*i, slotbase, i, ..]
+    ;; Compute the output offset = i*RECORD_SIZE.
+    dup2                   ; [i, slotbase, i, ..]
+    push RECORD_SIZE       ; [size, i, slotbase, i, ..]
+    mul                    ; [offset=size*i, slotbase, i, ..]
 
-  ;; Read slot 'addr' from storage.
-  dup2                  ;; [slotbase, offset, slotbase, ..]
-  sload                 ;; [addr, offset, slotbase, ..]
+    ;; Read slot 'addr' from storage.
+    dup2                   ; [slotbase, offset, slotbase, ..]
+    sload                  ; [addr, offset, slotbase, ..]
 
-  ;; Shift addr bytes.
-  push 12*8             ;; [96, addr, offset, slotbase, ..]
-  shl                   ;; [addr<<96, offset, slotbase, ..]
+    ;; Shift addr bytes.
+    push 12 * 8            ; [96, addr, offset, slotbase, ..]
+    shl                    ; [addr<<96, offset, slotbase, ..]
 
-  ;; Store addr at offset = i*RECORD_SIZE.
-  dup2                  ;; [offset, addr<<96, offset, slotbase, ..]
-  mstore                ;; [offset, slotbase, ..]
-  push 20               ;; [20, offset, slotbase, ..]
-  add                   ;; [offset=offset+20, slotbase, ..]
+    ;; Store addr at offset = i*RECORD_SIZE.
+    dup2                   ; [offset, addr<<96, offset, slotbase, ..]
+    mstore                 ; [offset, slotbase, ..]
+    push 20                ; [20, offset, slotbase, ..]
+    add                    ; [offset=offset+20, slotbase, ..]
 
-  ;; Read slot 'spk1' from storage.
-  dup2                  ;; [slotbase, offset, slotbase, ..]
-  push 1                ;; [1, slotbase, offset, slotbase, ..]
-  add                   ;; [slot, offset, slotbase, ..]
-  sload                 ;; [spk1, offset, slotbase, ..]
+    ;; Read slot 'spk1' from storage.
+    dup2                   ; [slotbase, offset, slotbase, ..]
+    push 1                 ; [1, slotbase, offset, slotbase, ..]
+    add                    ; [slot, offset, slotbase, ..]
+    sload                  ; [spk1, offset, slotbase, ..]
 
-  ;; Store spk1 at output offset = i*RECORD_SIZE+20.
-  dup2                  ;; [offset, spk1, offset, slotbase, ..]
-  mstore                ;; [offset, slotbase, ..]
-  push 32               ;; [32, offset, slotbase, ..]
-  add                   ;; [offset=offset+32, slotbase, ..]
+    ;; Store spk1 at output offset = i*RECORD_SIZE+20.
+    dup2                   ; [offset, spk1, offset, slotbase, ..]
+    mstore                 ; [offset, slotbase, ..]
+    push 32                ; [32, offset, slotbase, ..]
+    add                    ; [offset=offset+32, slotbase, ..]
 
-  ;; Read slot 'spk2_tpk1' from storage.
-  dup2                  ;; [slotbase, offset, slotbase, ..]
-  push 2                ;; [2, slotbase, offset, slotbase, ..]
-  add                   ;; [slot, offset, slotbase, ..]
-  sload                 ;; [spk2_tpk1, offset, slotbase, ..]
+    ;; Read slot 'spk2_tpk1' from storage.
+    dup2                   ; [slotbase, offset, slotbase, ..]
+    push 2                 ; [2, slotbase, offset, slotbase, ..]
+    add                    ; [slot, offset, slotbase, ..]
+    sload                  ; [spk2_tpk1, offset, slotbase, ..]
 
-  ;; Store spk2_tpk1 at output offset = i*RECORD_SIZE+52.
-  dup2                  ;; [offset, src[32:48] ++ tgt[0:16], offset, slotbase, ..]
-  mstore                ;; [offset, slotbase, ..]
-  push 32               ;; [32, offset, slotbase, ..]
-  add                   ;; [offset=offset+32, slotbase, ..]
+    ;; Store spk2_tpk1 at output offset = i*RECORD_SIZE+52.
+    dup2                   ; [offset, src[32:48] ++ tgt[0:16], offset, slotbase, ..]
+    mstore                 ; [offset, slotbase, ..]
+    push 32                ; [32, offset, slotbase, ..]
+    add                    ; [offset=offset+32, slotbase, ..]
 
-  ;; Read target[16:48] from slot 3.
-  swap1                 ;; [slotbase, offset, ..]
-  push 3                ;; [3, slotbase, offset, ..]
-  add                   ;; [slot, offset, ..]
-  sload                 ;; [tpk2, offset, ..]
+    ;; Read target[16:48] from slot 3.
+    swap1                  ; [slotbase, offset, ..]
+    push 3                 ; [3, slotbase, offset, ..]
+    add                    ; [slot, offset, ..]
+    sload                  ; [tpk2, offset, ..]
 
-  ;; Store tpk2 at output offset = i*RECORD_SIZE+84.
-  swap1                 ;; [offset, tpk2, ..]
-  mstore                ;; [..]
+    ;; Store tpk2 at output offset = i*RECORD_SIZE+84.
+    swap1                  ; [offset, tpk2, ..]
+    mstore                 ; [..]
 
-  ;; Increment i.
-  push 1                ;; [1, i, ..]
-  add                   ;; [i+1, ..]
+    ;; Increment i.
+    push 1                 ; [1, i, ..]
+    add                    ; [i+1, ..]
 
-  jump @accum_loop      ;; [i, count, head_idx, tail_idx]
+    jump @accum_loop       ; [i, count, head_idx, tail_idx]
 
 update_head:
-  ;; All requests have been read, update queue by adding the count read. to the
-  ;; current head index.
-  swap2                 ;; [head_idx, count, count, tail_idx]
-  add                   ;; [new_head_idx, count, tail_idx]
+    ;; All requests have been read, update queue by adding the count read. to the
+    ;; current head index.
+    swap2                  ; [head_idx, count, count, tail_idx]
+    add                    ; [new_head_idx, count, tail_idx]
 
-  ;; If the new head is equal to the tail, reset the queue by zeroing them both.
-  dup1                  ;; [new_head_idx, new_head_idx, count, tail_idx]
-  swap3                 ;; [tail_idx, new_head_idx, count, new_head_idx]
-  eq                    ;; [new_head_idx == tail_idx, count, new_head_idx]
-  jumpi @reset_queue    ;; [count, new_head_idx]
+    ;; If the new head is equal to the tail, reset the queue by zeroing them both.
+    dup1                   ; [new_head_idx, new_head_idx, count, tail_idx]
+    swap3                  ; [tail_idx, new_head_idx, count, new_head_idx]
+    eq                     ; [new_head_idx == tail_idx, count, new_head_idx]
+    jumpi @reset_queue     ; [count, new_head_idx]
 
-  ;; Otherwise, write the new head to storage.
-  swap1                 ;; [new_head_idx, count]
-  push QUEUE_HEAD       ;; [head_idx_slot, new_head_idx, count]
-  sstore                ;; [count]
+    ;; Otherwise, write the new head to storage.
+    swap1                  ; [new_head_idx, count]
+    push QUEUE_HEAD        ; [head_idx_slot, new_head_idx, count]
+    sstore                 ; [count]
 
-  jump @update_excess   ;; [count]
+    jump @update_excess    ; [count]
 
 reset_queue:
-  ;; Since the queue is empty, both the head and tail indexes can be zeroed.
-  swap1                 ;; [new_head_idx, count]
-  pop                   ;; [count]
+    ;; Since the queue is empty, both the head and tail indexes can be zeroed.
+    swap1                  ; [new_head_idx, count]
+    pop                    ; [count]
 
-  push 0                ;; [0, count]
-  push QUEUE_HEAD       ;; [head_slot, 0, count]
-  sstore                ;; [count]
+    push 0                 ; [0, count]
+    push QUEUE_HEAD        ; [head_slot, 0, count]
+    sstore                 ; [count]
 
-  push 0                ;; [0, count]
-  push QUEUE_TAIL       ;; [tail_slot, 0, count]
-  sstore                ;; [count]
+    push 0                 ; [0, count]
+    push QUEUE_TAIL        ; [tail_slot, 0, count]
+    sstore                 ; [count]
 
 update_excess:
-  ;; Update the new excess consolidation requests.
-  push SLOT_EXCESS      ;; [excess_slot, count]
-  sload                 ;; [excess, count]
+    ;; Update the new excess consolidation requests.
+    push SLOT_EXCESS       ; [excess_slot, count]
+    sload                  ; [excess, count]
 
-  ;; Check if excess needs to be reset to 0 for first iteration after
-  ;; activation.
-  dup1                  ;; [excess, excess, count]
-  push EXCESS_INHIBITOR ;; [inhibitor, excess, excess, count]
-  eq                    ;; [inhibitor == excess, excess, count]
-  iszero                ;; [inhibitor != excess, excess, count]
-  jumpi @skip_reset     ;; [excess, count]
+    ;; Check if excess needs to be reset to 0 for first iteration after
+    ;; activation.
+    dup1                   ; [excess, excess, count]
+    push EXCESS_INHIBITOR  ; [inhibitor, excess, excess, count]
+    eq                     ; [inhibitor == excess, excess, count]
+    iszero                 ; [inhibitor != excess, excess, count]
+    jumpi @skip_reset      ; [excess, count]
 
-  ;; Drop the excess from stack and use 0.
-  pop                   ;; [count]
-  push 0                ;; [reset_excess, count]
+    ;; Drop the excess from stack and use 0.
+    pop                    ; [count]
+    push 0                 ; [reset_excess, count]
 
 skip_reset:
-  push SLOT_COUNT       ;; [count_slot, excess, count]
-  sload                 ;; [count, excess, count]
+    push SLOT_COUNT        ; [count_slot, excess, count]
+    sload                  ; [count, excess, count]
 
-  ;; If the sum of the previous excess requests and requests added in the
-  ;; current block is greater than the target, subtract the target from the sum
-  ;; and set it as the new excess requests value.
-  push TARGET_PER_BLOCK ;; [target, count, excess, count]
-  dup3                  ;; [excess, target, count, excess, count]
-  dup3                  ;; [count, excess, target, count, excess, count]
-  add                   ;; [count+excess, target, count, excess, count]
-  gt                    ;; [count+excess > target, count, excess, count]
-  jumpi @compute_excess ;; [count, excess, count]
+    ;; If the sum of the previous excess requests and requests added in the
+    ;; current block is greater than the target, subtract the target from the sum
+    ;; and set it as the new excess requests value.
+    push TARGET_PER_BLOCK  ; [target, count, excess, count]
+    dup3                   ; [excess, target, count, excess, count]
+    dup3                   ; [count, excess, target, count, excess, count]
+    add                    ; [count+excess, target, count, excess, count]
+    gt                     ; [count+excess > target, count, excess, count]
+    jumpi @compute_excess  ; [count, excess, count]
 
-  ;; Zero out excess.
-  pop                   ;; [excess, count]
-  pop                   ;; [count]
-  push 0                ;; [0, count]
-  jump @store_excess    ;; [0, count]
+    ;; Zero out excess.
+    pop                    ; [excess, count]
+    pop                    ; [count]
+    push 0                 ; [0, count]
+    jump @store_excess     ; [0, count]
 
 compute_excess:
-  add                   ;; [count+excess, count]
-  push TARGET_PER_BLOCK ;; [target, count+excess, count]
-  swap1                 ;; [count+excess, target, count]
-  sub                   ;; [new_excess, count]
+    add                    ; [count+excess, count]
+    push TARGET_PER_BLOCK  ; [target, count+excess, count]
+    swap1                  ; [count+excess, target, count]
+    sub                    ; [new_excess, count]
 
 store_excess:
-  push SLOT_EXCESS      ;; [excess_slot, new_excess, count]
-  sstore                ;; [count]
+    push SLOT_EXCESS       ; [excess_slot, new_excess, count]
+    sstore                 ; [count]
 
-  ;; Reset request count.
-  push 0                ;; [0, count]
-  push SLOT_COUNT       ;; [count_slot, 0, count]
-  sstore                ;; [count]
+    ;; Reset request count.
+    push 0                 ; [0, count]
+    push SLOT_COUNT        ; [count_slot, 0, count]
+    sstore                 ; [count]
 
-  ;; Return the requests.
-  push RECORD_SIZE      ;; [record_size, count]
-  mul                   ;; [size]
-  push 0                ;; [0, size]
-  return                ;; []
+    ;; Return the requests.
+    push RECORD_SIZE       ; [record_size, count]
+    mul                    ; [size]
+    push 0                 ; [0, size]
+    return                 ; []
 
-;; Revert subroutine.
+    ;; Revert subroutine.
 revert:
-  push 0
-  push 0
-  revert
+    push 0
+    push 0
+    revert

--- a/src/execution_hash/ctor.eas
+++ b/src/execution_hash/ctor.eas
@@ -1,10 +1,10 @@
-  ;; Copy and return code.
-  push len(code)     ; [len]
-  dup1               ; [len, len]
-  push @code         ; [codeOffset, len, len]
-  push 0             ; [dest, codeOffset, len, len]
-  codecopy           ; [len]
-  push 0             ; [ptr, len]
-  return             ; []
+    ;; Copy and return code.
+    push len(code)     ; [len]
+    dup1               ; [len, len]
+    push @code         ; [codeOffset, len, len]
+    push 0             ; [dest, codeOffset, len, len]
+    codecopy           ; [len]
+    push 0             ; [ptr, len]
+    return             ; []
 
 #bytes code: assemble("main.eas")

--- a/src/execution_hash/main.eas
+++ b/src/execution_hash/main.eas
@@ -1,94 +1,94 @@
-;; ┏┓┏┓┏┓┏━      
-;; ┏┛┗┫ ┫┗┓┏┓┏┏┳┓
-;; ┗━┗┛┗┛┗┛┗┻┛┛┗┗
-;;                                             
-;; This is an implementation of EIP-2935's predeploy contract.
-;;
-;; The contract implements a ring buffer to create bounded execution block hash
-;; lookup. 
+;;; ┏┓┏┓┏┓┏━
+;;; ┏┛┗┫ ┫┗┓┏┓┏┏┳┓
+;;; ┗━┗┛┗┛┗┛┗┻┛┛┗┗
+;;;
+;;; This is an implementation of EIP-2935's predeploy contract.
+;;;
+;;; The contract implements a ring buffer to create bounded execution block hash
+;;; lookup.
 
 #pragma target "prague"
 
-;; ----------------------------------------------------------------------------
-;; MACROS ---------------------------------------------------------------------
-;; ----------------------------------------------------------------------------
+;;; ----------------------------------------------------------------------------
+;;; MACROS ---------------------------------------------------------------------
+;;; ----------------------------------------------------------------------------
 
-;; BUFLEN returns the HISTORY_BUFFER_LENGTH as defined in the EIP.
+;;; BUFLEN returns the HISTORY_BUFFER_LENGTH as defined in the EIP.
 #define BUFLEN = 8191
 
-;; SYSADDR is the address which calls the contract to submit a new block hash.
+;;; SYSADDR is the address which calls the contract to submit a new block hash.
 #define SYSADDR = .address(0xfffffffffffffffffffffffffffffffffffffffe)
 
-;; ----------------------------------------------------------------------------
-;; MACROS END -----------------------------------------------------------------
-;; ----------------------------------------------------------------------------
+;;; ----------------------------------------------------------------------------
+;;; MACROS END -----------------------------------------------------------------
+;;; ----------------------------------------------------------------------------
 
-  ;; Protect the submit routine by verifying the caller is equal to
-  ;; sysaddr().
-  caller            ;; [caller]
-  push SYSADDR      ;; [sysaddr, caller]
-  eq                ;; [sysaddr == caller]
-  jumpi @submit     ;; []
+    ;; Protect the submit routine by verifying the caller is equal to
+    ;; sysaddr().
+    caller             ; [caller]
+    push SYSADDR       ; [sysaddr, caller]
+    eq                 ; [sysaddr == caller]
+    jumpi @submit      ; []
 
-  ;; Fallthrough if addresses don't match -- this means the caller intends
-  ;; to read a block hash.
+    ;; Fallthrough if addresses don't match -- this means the caller intends
+    ;; to read a block hash.
 
-  ;; Verify input is 32 bytes long.
-  push 32           ;; [32]
-  calldatasize      ;; [calldatasize, 32]
-  sub               ;; [calldatasize - 32]
+    ;; Verify input is 32 bytes long.
+    push 32            ; [32]
+    calldatasize       ; [calldatasize, 32]
+    sub                ; [calldatasize - 32]
 
-  ;; Jump to continue if length-check passed, otherwise revert.
-  jumpi @throw      ;; []
+    ;; Jump to continue if length-check passed, otherwise revert.
+    jumpi @throw       ; []
 
-  ;; Check if input is requesting a block hash greater than current block number
-  ;; minus 1.
-  push 0            ;; [0]
-  calldataload      ;; [input]
-  push 1            ;; [1, input]
-  number            ;; [number, 1, input]
-  sub               ;; [number-1, input]              
-  dup2              ;; [input, number-1, input]
-  gt                ;; [input > number-1, input]
-  jumpi @throw      ;; [input]
+    ;; Check if input is requesting a block hash greater than current block number
+    ;; minus 1.
+    push 0             ; [0]
+    calldataload       ; [input]
+    push 1             ; [1, input]
+    number             ; [number, 1, input]
+    sub                ; [number-1, input]
+    dup2               ; [input, number-1, input]
+    gt                 ; [input > number-1, input]
+    jumpi @throw       ; [input]
 
-  ;; Check if the input is requesting a block hash before the earliest available
-  ;; hash currently. Since we've verified that input <= number - 1, we know
-  ;; there will be no overflow during the subtraction of number - input.
-  push BUFLEN       ;; [buflen, input]
-  dup2              ;; [input, buflen, input]
-  number            ;; [number, input, buflen, input]
-  sub               ;; [number - input, buflen, input]
-  gt                ;; [number - input > buflen, input]
-  jumpi @throw      ;; [input]
+    ;; Check if the input is requesting a block hash before the earliest available
+    ;; hash currently. Since we've verified that input <= number - 1, we know
+    ;; there will be no overflow during the subtraction of number - input.
+    push BUFLEN        ; [buflen, input]
+    dup2               ; [input, buflen, input]
+    number             ; [number, input, buflen, input]
+    sub                ; [number - input, buflen, input]
+    gt                 ; [number - input > buflen, input]
+    jumpi @throw       ; [input]
 
-  ;; Load the hash.
-  push BUFLEN       ;; [buflen, input]
-  swap1             ;; [input, buflen]
-  mod               ;; [input % buflen]
-  sload             ;; [hash]
+    ;; Load the hash.
+    push BUFLEN        ; [buflen, input]
+    swap1              ; [input, buflen]
+    mod                ; [input % buflen]
+    sload              ; [hash]
 
-  ;; Load into memory and return.
-  push 0            ;; [0, hash]
-  mstore            ;; []
-  push 32           ;; [32]
-  push 0            ;; [0, 32]
-  return            ;; []
+    ;; Load into memory and return.
+    push 0             ; [0, hash]
+    mstore             ; []
+    push 32            ; [32]
+    push 0             ; [0, 32]
+    return             ; []
 
 throw:
-  ;; Reverts current execution with no return data.
-  push 0            ;; [0]
-  push 0            ;; [0, 0]
-  revert            ;; []
+    ;; Reverts current execution with no return data.
+    push 0             ; [0]
+    push 0             ; [0, 0]
+    revert             ; []
 
 submit:
-  push 0            ;; [0]
-  calldataload      ;; [in]
-  push BUFLEN       ;; [buflen, in]
-  push 1            ;; [1, buflen, in]
-  number            ;; [number, 1, buflen, in]
-  sub               ;; [number-1, buflen, in]
-  mod               ;; [number-1 % buflen, in]
-  sstore
+    push 0             ; [0]
+    calldataload       ; [in]
+    push BUFLEN        ; [buflen, in]
+    push 1             ; [1, buflen, in]
+    number             ; [number, 1, buflen, in]
+    sub                ; [number-1, buflen, in]
+    mod                ; [number-1 % buflen, in]
+    sstore
 
-  stop
+    stop

--- a/src/withdrawals/ctor.eas
+++ b/src/withdrawals/ctor.eas
@@ -1,16 +1,16 @@
-  ;; Store 0xff..ff as a temporary excess value to avoid requests being queued
-  ;; before the fork.
-  push (1<<256)-1    ; [excess]
-  push 0             ; [slot, excess]
-  sstore             ; []
+    ;; Store 0xff..ff as a temporary excess value to avoid requests being queued
+    ;; before the fork.
+    push (1 << 256) - 1  ; [excess]
+    push 0               ; [slot, excess]
+    sstore               ; []
 
-  ;; Copy and return code.
-  push len(code)     ; [len]
-  dup1               ; [len, len]
-  push @code         ; [codeOffset, len, len]
-  push 0             ; [dest, codeOffset, len, len]
-  codecopy           ; [len]
-  push 0             ; [ptr, len]
-  return             ; []
+    ;; Copy and return code.
+    push len(code)       ; [len]
+    dup1                 ; [len, len]
+    push @code           ; [codeOffset, len, len]
+    push 0               ; [dest, codeOffset, len, len]
+    codecopy             ; [len]
+    push 0               ; [ptr, len]
+    return               ; []
 
 #bytes code: assemble("main.eas")

--- a/src/withdrawals/main.eas
+++ b/src/withdrawals/main.eas
@@ -1,27 +1,27 @@
-;; ███████╗ ██████╗  ██████╗ ██████╗   █████╗ ███████╗███╗   ███╗
-;; ╚════██║██╔═████╗██╔═████╗╚════██╗ ██╔══██╗██╔════╝████╗ ████║
-;;     ██╔╝██║██╔██║██║██╔██║ █████╔╝ ███████║███████╗██╔████╔██║
-;;    ██╔╝ ████╔╝██║████╔╝██║██╔═══╝  ██╔══██║╚════██║██║╚██╔╝██║
-;;    ██║  ╚██████╔╝╚██████╔╝███████╗ ██║  ██║███████║██║ ╚═╝ ██║
-;;    ╚═╝   ╚═════╝  ╚═════╝ ╚══════╝ ╚═╝  ╚═╝╚══════╝╚═╝     ╚═╝
-;;
-;; This is an implementation of EIP-7002's pre-deploy contract. It implements an
-;; unvalidated withdrawal requests queue for beacon chain validators. The queue
-;; is tracked using head and tail index pointers. After the queue is emptied,
-;; the pointers are reset to zero.
-;;
-;; Entrance to the queue is determined only by a call's ability to pay the
-;; exponentially increasing fee. This fee is computed using a simple function
-;; which approximates true exponential value. No verification of ownership is
-;; done by the pre-deploy or the execution layer. Only once the requests are
-;; being processed by the beacon chain is the validity verified. The fee is used
-;; to avoid spamming of the withdrawal requests queue.
+;;; ███████╗ ██████╗  ██████╗ ██████╗   █████╗ ███████╗███╗   ███╗
+;;; ╚════██║██╔═████╗██╔═████╗╚════██╗ ██╔══██╗██╔════╝████╗ ████║
+;;;     ██╔╝██║██╔██║██║██╔██║ █████╔╝ ███████║███████╗██╔████╔██║
+;;;    ██╔╝ ████╔╝██║████╔╝██║██╔═══╝  ██╔══██║╚════██║██║╚██╔╝██║
+;;;    ██║  ╚██████╔╝╚██████╔╝███████╗ ██║  ██║███████║██║ ╚═╝ ██║
+;;;    ╚═╝   ╚═════╝  ╚═════╝ ╚══════╝ ╚═╝  ╚═╝╚══════╝╚═╝     ╚═╝
+;;;
+;;; This is an implementation of EIP-7002's pre-deploy contract. It implements an
+;;; unvalidated withdrawal requests queue for beacon chain validators. The queue
+;;; is tracked using head and tail index pointers. After the queue is emptied,
+;;; the pointers are reset to zero.
+;;;
+;;; Entrance to the queue is determined only by a call's ability to pay the
+;;; exponentially increasing fee. This fee is computed using a simple function
+;;; which approximates true exponential value. No verification of ownership is
+;;; done by the pre-deploy or the execution layer. Only once the requests are
+;;; being processed by the beacon chain is the validity verified. The fee is used
+;;; to avoid spamming of the withdrawal requests queue.
 
 #pragma target "prague"
 
-;; -----------------------------------------------------------------------------
-;; CONSTANTS -------------------------------------------------------------------
-;; -----------------------------------------------------------------------------
+;;; -----------------------------------------------------------------------------
+;;; CONSTANTS -------------------------------------------------------------------
+;;; -----------------------------------------------------------------------------
 
 #define SYSTEM_ADDR = .address(0xfffffffffffffffffffffffffffffffffffffffe)
 
@@ -38,450 +38,451 @@
 #define FEE_UPDATE_FRACTION = 17
 #define EXCESS_INHIBITOR = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 
-#define INPUT_SIZE = 56    ;; the size of (pubkey ++ amount)
-#define RECORD_SIZE = 76   ;; the size of (address ++ pubkey ++ amount)
-#define SLOTS_PER_ITEM = 3 ;; (address, pubkey[0:32], pubkey[32:48] ++ amount)
+#define INPUT_SIZE = 56      ; the size of (pubkey ++ amount)
+#define RECORD_SIZE = 76     ; the size of (address ++ pubkey ++ amount)
+#define SLOTS_PER_ITEM = 3   ; (address, pubkey[0:32], pubkey[32:48] ++ amount)
 
-;; ----------------------------------------------------------------------------
-;; PROGRAM START --------------------------------------------------------------
-;; ----------------------------------------------------------------------------
+;;; ----------------------------------------------------------------------------
+;;; PROGRAM START --------------------------------------------------------------
+;;; ----------------------------------------------------------------------------
 
-  ;; Protect the system subroutine by checking if the caller is the system
-  ;; address.
-  caller                ;; [caller]
-  push SYSTEM_ADDR      ;; [sysaddr, caller]
-  eq                    ;; [sysaddr == caller]
-  jumpi @read_requests  ;; []
+    ;; Protect the system subroutine by checking if the caller is the system
+    ;; address.
+    caller                   ; [caller]
+    push SYSTEM_ADDR         ; [sysaddr, caller]
+    eq                       ; [sysaddr == caller]
+    jumpi @read_requests     ; []
 
-  ;; --------------------------------------------------------------------------
-  ;; USER SUBROUTINE ----------------------------------------------------------
-  ;; --------------------------------------------------------------------------
+;;; --------------------------------------------------------------------------
+;;; USER SUBROUTINE ----------------------------------------------------------
+;;; --------------------------------------------------------------------------
 
-  ;; Compute the fee using fake expo and the current excess withdrawal requests.
-  push FEE_UPDATE_FRACTION
-  push SLOT_EXCESS      ;; [excess_slot, update_fraction]
-  sload                 ;; [excess, update_fraction]
+    ;; Compute the fee using fake expo and the current excess withdrawal requests.
+    push FEE_UPDATE_FRACTION
+    push SLOT_EXCESS         ; [excess_slot, update_fraction]
+    sload                    ; [excess, update_fraction]
 
-  ;; Check if the pre-fork inhibitor is still active, revert if so.
-  dup1                  ;; [excess, excess, update_fraction]
-  push EXCESS_INHIBITOR ;; [inhibitor, excess, excess, update_fraction]
-  eq                    ;; [inhibitor == excess, excess, update_fraction]
-  jumpi @revert         ;; [excess, update_fraction]
+    ;; Check if the pre-fork inhibitor is still active, revert if so.
+    dup1                     ; [excess, excess, update_fraction]
+    push EXCESS_INHIBITOR    ; [inhibitor, excess, excess, update_fraction]
+    eq                       ; [inhibitor == excess, excess, update_fraction]
+    jumpi @revert            ; [excess, update_fraction]
 
-  push MIN_FEE          ;; [min_fee, excess, update_fraction]
-  #include "../common/fake_expo.eas"
+    push MIN_FEE             ; [min_fee, excess, update_fraction]
+#include "../common/fake_expo.eas"
 
-  ;; If calldatasize matches the expected input size, go to adding the request.
-  calldatasize          ;; [calldatasize, req_fee]
-  push INPUT_SIZE       ;; [INPUT_SIZE, calldatasize, req_fee]
-  eq                    ;; [INPUT_SIZE == calldatasize, req_fee]
-  jumpi @handle_input
+    ;; If calldatasize matches the expected input size, go to adding the request.
+    calldatasize             ; [calldatasize, req_fee]
+    push INPUT_SIZE          ; [INPUT_SIZE, calldatasize, req_fee]
+    eq                       ; [INPUT_SIZE == calldatasize, req_fee]
+    jumpi @handle_input
 
-  ;; Otherwise calldatasize must be zero.
-  calldatasize          ;; [calldatasize, req_fee]
-  jumpi @revert         ;; [req_fee]
+    ;; Otherwise calldatasize must be zero.
+    calldatasize             ; [calldatasize, req_fee]
+    jumpi @revert            ; [req_fee]
 
-  ;; This is the read path, where we return the current fee.
-  ;; Reject any callvalue here to prevent lost funds.
-  callvalue             ;; [value, req_fee]
-  jumpi @revert
+    ;; This is the read path, where we return the current fee.
+    ;; Reject any callvalue here to prevent lost funds.
+    callvalue                ; [value, req_fee]
+    jumpi @revert
 
-  ;; Return req_fee.
-  push 0                ;; [0, req_fee]
-  mstore                ;; []
-  push 32               ;; [32]
-  push 0                ;; [0, 32]
-  return                ;; []
+    ;; Return req_fee.
+    push 0                   ; [0, req_fee]
+    mstore                   ; []
+    push 32                  ; [32]
+    push 0                   ; [0, 32]
+    return                   ; []
 
 handle_input:
-  ;; This is the write path. We expect the computed fee on the stack.
-  ;; Input data has the following layout:
-  ;;
-  ;;  +--------+--------+
-  ;;  | pubkey | amount |
-  ;;  +--------+--------+
-  ;;      48       8
+    ;; This is the write path. We expect the computed fee on the stack.
+    ;; Input data has the following layout:
+    ;;
+    ;;  +--------+--------+
+    ;;  | pubkey | amount |
+    ;;  +--------+--------+
+    ;;      48       8
 
-  ;; Determine if the fee provided is enough to cover the withdrawal request fee.
-  callvalue             ;; [callvalue, req_fee]
-  lt                    ;; [callvalue < req_fee]
-  jumpi @revert         ;; []
+    ;; Determine if the fee provided is enough to cover the withdrawal request fee.
+    callvalue                ; [callvalue, req_fee]
+    lt                       ; [callvalue < req_fee]
+    jumpi @revert            ; []
 
-  ;; The request can pay, increment withdrawal request count.
-  push SLOT_COUNT
-  sload                 ;; [req_count]
-  push 1                ;; [1, req_count]
-  add                   ;; [req_count+1]
-  push SLOT_COUNT       ;; [slot, req_count+1]
-  sstore                ;; []
+    ;; The request can pay, increment withdrawal request count.
+    push SLOT_COUNT
+    sload                    ; [req_count]
+    push 1                   ; [1, req_count]
+    add                      ; [req_count+1]
+    push SLOT_COUNT          ; [slot, req_count+1]
+    sstore                   ; []
 
-  ;; Now insert request into queue. First, compute the base storage slot
-  push QUEUE_TAIL       ;; [tail_idx_slot]
-  sload                 ;; [tail_idx]
-  dup1                  ;; [tail_idx, tail_idx]
-  push SLOTS_PER_ITEM   ;; [slots, tail_idx, tail_idx]
-  mul                   ;; [slots*tail_idx, tail_idx]
-  push QUEUE_OFFSET     ;; [ost, 3*tail_idx, tail_idx]
-  add                   ;; [slot, tail_idx]
+    ;; Now insert request into queue. First, compute the base storage slot
+    push QUEUE_TAIL          ; [tail_idx_slot]
+    sload                    ; [tail_idx]
+    dup1                     ; [tail_idx, tail_idx]
+    push SLOTS_PER_ITEM      ; [slots, tail_idx, tail_idx]
+    mul                      ; [slots*tail_idx, tail_idx]
+    push QUEUE_OFFSET        ; [ost, 3*tail_idx, tail_idx]
+    add                      ; [slot, tail_idx]
 
-  ;; Write address to queue.
-  caller                ;; [caller, slot, ..]
-  dup2                  ;; [slot, caller, slot, ..]
-  sstore                ;; [slot, ..]
+    ;; Write address to queue.
+    caller                   ; [caller, slot, ..]
+    dup2                     ; [slot, caller, slot, ..]
+    sstore                   ; [slot, ..]
 
-  push 1                ;; [1, slot, ..]
-  add                   ;; [slot, ..]
+    push 1                   ; [1, slot, ..]
+    add                      ; [slot, ..]
 
-  ;; Store pk[0:32] to queue.
-  push 0                ;; [0, slot, ..]
-  calldataload          ;; [pk[0:32], slot, ..]
-  dup2                  ;; [slot, pk[0:32], slot, ..]
-  sstore                ;; [slot, ..]
+    ;; Store pk[0:32] to queue.
+    push 0                   ; [0, slot, ..]
+    calldataload             ; [pk[0:32], slot, ..]
+    dup2                     ; [slot, pk[0:32], slot, ..]
+    sstore                   ; [slot, ..]
 
-  push 1                ;; [1, slot, ..]
-  add                   ;; [slot, ..]
+    push 1                   ; [1, slot, ..]
+    add                      ; [slot, ..]
 
-  ;; Store pk2_am to queue.
-  push 32               ;; [32, slot, ..]
-  calldataload          ;; [pk2_am, slot, ..]
-  swap1                 ;; [slot, pk2_am, ..]
-  sstore                ;; [..]
+    ;; Store pk2_am to queue.
+    push 32                  ; [32, slot, ..]
+    calldataload             ; [pk2_am, slot, ..]
+    swap1                    ; [slot, pk2_am, ..]
+    sstore                   ; [..]
 
-  ;; Assemble log data.
-  caller                ;; [caller, ..]
-  push 96               ;; [96, caller, ..]
-  shl                   ;; [caller, ..]
-  push 0                ;; [0, caller, ..]
-  mstore                ;; [..]
-  push INPUT_SIZE       ;; [size, ..]
-  push 0                ;; [ost, size, ..]
-  push 20               ;; [dest, ost, size, ..]
-  calldatacopy          ;; [..]
+    ;; Assemble log data.
+    caller                   ; [caller, ..]
+    push 96                  ; [96, caller, ..]
+    shl                      ; [caller, ..]
+    push 0                   ; [0, caller, ..]
+    mstore                   ; [..]
+    push INPUT_SIZE          ; [size, ..]
+    push 0                   ; [ost, size, ..]
+    push 20                  ; [dest, ost, size, ..]
+    calldatacopy             ; [..]
 
-  ;; Log record.
-  push RECORD_SIZE      ;; [size, ..]
-  push 0                ;; [idx, size, ..]
-  log0                  ;; [..]
+    ;; Log record.
+    push RECORD_SIZE         ; [size, ..]
+    push 0                   ; [idx, size, ..]
+    log0                     ; [..]
 
-  ;; Increment queue tail over last and write to storage.
-  push 1                ;; [1, tail_idx]
-  add                   ;; [tail_idx+1]
-  push QUEUE_TAIL       ;; [tail_idx_slot, tail_idx+1]
-  sstore                ;; []
+    ;; Increment queue tail over last and write to storage.
+    push 1                   ; [1, tail_idx]
+    add                      ; [tail_idx+1]
+    push QUEUE_TAIL          ; [tail_idx_slot, tail_idx+1]
+    sstore                   ; []
 
-  stop
+    stop
 
-;; ----------------------------------------------------------------------------
-;; SYSTEM SUBROUTINE ----------------------------------------------------------
-;; ----------------------------------------------------------------------------
-;;
-;; Pop withdrawal request from queue, update fee accumulator ~~
-;; This is the logic executed by the protocol each block. It reads as many
-;; requests as available from the queue, until the max withdrawal request per
-;; block is reached. The requests are returned as a contiguous array of bytes
-;; with each record being exactly 76 bytes.
-;;
-;;  Withdrawal request record:
-;;
-;;  +------+--------+--------+
-;;  | addr | pubkey | amount |
-;;  +------+--------+--------+
-;;     20      48        8
-;;
-;; Because the requests are stored across three storage slots, there is some
-;; shuffling to align the data.
-;;
-;; After reading the withdrawal requests, they are removed from the queue by
-;; modifying the queue's head index. The excess requests accumulator is updated
-;; so that the new cost of requesting a withdrawal is reflected. Finally, the
-;; request count is reset.
+;;; ----------------------------------------------------------------------------
+;;; SYSTEM SUBROUTINE ----------------------------------------------------------
+;;; ----------------------------------------------------------------------------
+;;;
+;;; Pop withdrawal request from queue, update fee accumulator ~~
+;;; This is the logic executed by the protocol each block. It reads as many
+;;; requests as available from the queue, until the max withdrawal request per
+;;; block is reached. The requests are returned as a contiguous array of bytes
+;;; with each record being exactly 76 bytes.
+;;;
+;;;  Withdrawal request record:
+;;;
+;;;  +------+--------+--------+
+;;;  | addr | pubkey | amount |
+;;;  +------+--------+--------+
+;;;     20      48        8
+;;;
+;;; Because the requests are stored across three storage slots, there is some
+;;; shuffling to align the data.
+;;;
+;;; After reading the withdrawal requests, they are removed from the queue by
+;;; modifying the queue's head index. The excess requests accumulator is updated
+;;; so that the new cost of requesting a withdrawal is reflected. Finally, the
+;;; request count is reset.
+
 read_requests:
-  ;; Determine the size of the queue by calculating tail - head.
-  push QUEUE_TAIL       ;; [tail_idx_slot]
-  sload                 ;; [tail_idx]
-  push QUEUE_HEAD       ;; [head_idx_slot, tail_idx]
-  sload                 ;; [head_idx, tail_idx]
+    ;; Determine the size of the queue by calculating tail - head.
+    push QUEUE_TAIL          ; [tail_idx_slot]
+    sload                    ; [tail_idx]
+    push QUEUE_HEAD          ; [head_idx_slot, tail_idx]
+    sload                    ; [head_idx, tail_idx]
 
-  ;; Now compute the count.
-  dup1                  ;; [head_idx, head_idx, tail_idx]
-  dup3                  ;; [tail_idx, head_idx, head_idx, tail_idx]
-  sub                   ;; [count, head_idx, tail_idx]
+    ;; Now compute the count.
+    dup1                     ; [head_idx, head_idx, tail_idx]
+    dup3                     ; [tail_idx, head_idx, head_idx, tail_idx]
+    sub                      ; [count, head_idx, tail_idx]
 
-  ;; Determine if count is greater than the max withdrawal requests.
-  dup1                  ;; [count, count, head_idx, tail_idx]
-  push MAX_PER_BLOCK    ;; [reqs_per_block, count, count, head_idx, tail_idx]
-  gt                    ;; [reqs_per_block > count, count, head_idx, tail_idx]
-  jumpi @begin_loop     ;; [count, head_idx, tail_idx]
+    ;; Determine if count is greater than the max withdrawal requests.
+    dup1                     ; [count, count, head_idx, tail_idx]
+    push MAX_PER_BLOCK       ; [reqs_per_block, count, count, head_idx, tail_idx]
+    gt                       ; [reqs_per_block > count, count, head_idx, tail_idx]
+    jumpi @begin_loop        ; [count, head_idx, tail_idx]
 
-  ;; Discard count, use the max withdrawal requests per block.
-  pop                   ;; [head_idx, tail_idx]
-  push MAX_PER_BLOCK    ;; [count, head_idx, tail_idx]
+    ;; Discard count, use the max withdrawal requests per block.
+    pop                      ; [head_idx, tail_idx]
+    push MAX_PER_BLOCK       ; [count, head_idx, tail_idx]
 
 begin_loop:
-  push 0                ;; [i, count, head_idx, tail_idx]
+    push 0                   ; [i, count, head_idx, tail_idx]
 
 accum_loop:
-  ;; This loop will read each request and byte bang it into a 76 byte chunk.
+    ;; This loop will read each request and byte bang it into a 76 byte chunk.
 
-  ;; Bounds check, ensure i < count.
-  dup2                  ;; [count, i, count, head_idx, tail_idx]
-  dup2                  ;; [i, count, i, count, head_idx, tail_idx]
-  eq                    ;; [i == count, i, count, head_idx, tail_idx]
-  jumpi @update_head    ;; [i, count, head_idx, tail_idx]
+    ;; Bounds check, ensure i < count.
+    dup2                     ; [count, i, count, head_idx, tail_idx]
+    dup2                     ; [i, count, i, count, head_idx, tail_idx]
+    eq                       ; [i == count, i, count, head_idx, tail_idx]
+    jumpi @update_head       ; [i, count, head_idx, tail_idx]
 
-  ;; Determine the storage slot of the address for this iteration. This value is
-  ;; also the base for the other two storage slots containing the public key and
-  ;; amount. The base slot will be (queue_offset + queue_head*3 + i*3).
-  dup3                  ;; [head_idx, i, count, head_idx, ..]
-  dup2                  ;; [i, head_idx, i, ..]
-  add                   ;; [i+head_idx, i, ..]
-  push 3                ;; [3, i+head_idx, i, ..]
-  mul                   ;; [3*(i+head_idx), i, ..]
-  push QUEUE_OFFSET     ;; [queue_offset, 3*(i+head_idx), i, ..]
-  add                   ;; [slotbase, i, ..]
+    ;; Determine the storage slot of the address for this iteration. This value is
+    ;; also the base for the other two storage slots containing the public key and
+    ;; amount. The base slot will be (queue_offset + queue_head*3 + i*3).
+    dup3                     ; [head_idx, i, count, head_idx, ..]
+    dup2                     ; [i, head_idx, i, ..]
+    add                      ; [i+head_idx, i, ..]
+    push 3                   ; [3, i+head_idx, i, ..]
+    mul                      ; [3*(i+head_idx), i, ..]
+    push QUEUE_OFFSET        ; [queue_offset, 3*(i+head_idx), i, ..]
+    add                      ; [slotbase, i, ..]
 
-  ;; Write values to memory flat and contiguously. This requires combining the
-  ;; three storage elements (addr, pk1, pk2_am) so there is no padding.
-  ;;
-  ;; The slots have the following layout:
-  ;;
-  ;; 0: addr
-  ;;  0x00 | 00 00 00 00 00 00 00 00 00 00 00 00 aa aa aa aa
-  ;;  0x10 | aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa
-  ;;
-  ;; 1: pk[0:32] -> pk1
-  ;;  0x00 | bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb
-  ;;  0x10 | bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb
-  ;;
-  ;; 2: pk[32:48] ++ am[0:8] -> pk2_am
-  ;;  0x00 | bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb
-  ;;  0x10 | cc cc cc cc cc cc cc cc 00 00 00 00 00 00 00 00
+    ;; Write values to memory flat and contiguously. This requires combining the
+    ;; three storage elements (addr, pk1, pk2_am) so there is no padding.
+    ;;
+    ;; The slots have the following layout:
+    ;;
+    ;; 0: addr
+    ;;  0x00 | 00 00 00 00 00 00 00 00 00 00 00 00 aa aa aa aa
+    ;;  0x10 | aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa aa
+    ;;
+    ;; 1: pk[0:32] -> pk1
+    ;;  0x00 | bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb
+    ;;  0x10 | bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb
+    ;;
+    ;; 2: pk[32:48] ++ am[0:8] -> pk2_am
+    ;;  0x00 | bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb bb
+    ;;  0x10 | cc cc cc cc cc cc cc cc 00 00 00 00 00 00 00 00
 
-  ;; Compute the output offset = i*RECORD_SIZE.
-  dup2                  ;; [i, slotbase, i, ..]
-  push RECORD_SIZE      ;; [size, i, slotbase, i, ..]
-  mul                   ;; [offset=size*i, slotbase, i, ..]
+    ;; Compute the output offset = i*RECORD_SIZE.
+    dup2                     ; [i, slotbase, i, ..]
+    push RECORD_SIZE         ; [size, i, slotbase, i, ..]
+    mul                      ; [offset=size*i, slotbase, i, ..]
 
-  ;; Read slot 'addr' from storage.
-  dup2                  ;; [slotbase, offset, slotbase, ..]
-  sload                 ;; [addr, offset, slotbase, ..]
+    ;; Read slot 'addr' from storage.
+    dup2                     ; [slotbase, offset, slotbase, ..]
+    sload                    ; [addr, offset, slotbase, ..]
 
-  ;; Shift addr bytes.
-  push 12*8             ;; [96, addr, offset, slotbase, ..]
-  shl                   ;; [addr<<96, offset, slotbase, ..]
+    ;; Shift addr bytes.
+    push 12 * 8              ; [96, addr, offset, slotbase, ..]
+    shl                      ; [addr<<96, offset, slotbase, ..]
 
-  ;; Store addr at output offset = i*RECORD_SIZE.
-  dup2                  ;; [offset, addr<<96, offset, slotbase, ..]
-  mstore                ;; [offset, slotbase, ..]
-  push 20               ;; [20, offset, slotbase, ..]
-  add                   ;; [offset=offset+20, slotbase, ..]
+    ;; Store addr at output offset = i*RECORD_SIZE.
+    dup2                     ; [offset, addr<<96, offset, slotbase, ..]
+    mstore                   ; [offset, slotbase, ..]
+    push 20                  ; [20, offset, slotbase, ..]
+    add                      ; [offset=offset+20, slotbase, ..]
 
-  ;; Read slot 'pk1' from storage.
-  dup2                  ;; [slotbase, offset, slotbase, ..]
-  push 1                ;; [1, slotbase, offset, slotbase, ..]
-  add                   ;; [slot, offset, slotbase, ..]
-  sload                 ;; [pk1, offset, slotbase, ..]
+    ;; Read slot 'pk1' from storage.
+    dup2                     ; [slotbase, offset, slotbase, ..]
+    push 1                   ; [1, slotbase, offset, slotbase, ..]
+    add                      ; [slot, offset, slotbase, ..]
+    sload                    ; [pk1, offset, slotbase, ..]
 
-  ;; Store pk1 at output offset = i*RECORD_SIZE + 20.
-  dup2                  ;; [offset, pk1, offset, slotbase, ..]
-  mstore                ;; [offset, slotbase, ..]
-  push 32               ;; [32, offset, slotbase, ..]
-  add                   ;; [offset=offset+32, slotbase, ..]
+    ;; Store pk1 at output offset = i*RECORD_SIZE + 20.
+    dup2                     ; [offset, pk1, offset, slotbase, ..]
+    mstore                   ; [offset, slotbase, ..]
+    push 32                  ; [32, offset, slotbase, ..]
+    add                      ; [offset=offset+32, slotbase, ..]
 
-  ;; Read slot 'pk2_am' from storage.
-  swap1                 ;; [slotbase, offset, ..]
-  push 2                ;; [2, slotbase, offset, ..]
-  add                   ;; [slot, offset, ..]
-  sload                 ;; [pk2_am, offset, ..]
+    ;; Read slot 'pk2_am' from storage.
+    swap1                    ; [slotbase, offset, ..]
+    push 2                   ; [2, slotbase, offset, ..]
+    add                      ; [slot, offset, ..]
+    sload                    ; [pk2_am, offset, ..]
 
-  ;; Extract pk2 from pk2_am.
-  dup1                  ;; [pk2_am, pk2_am, offset, ..]
-  push pk2_mask         ;; [mask, pk2_am, pk2_am, offset, ..]
-  and                   ;; [pk2, pk2_am, offset, ..]
+    ;; Extract pk2 from pk2_am.
+    dup1                     ; [pk2_am, pk2_am, offset, ..]
+    push pk2_mask            ; [mask, pk2_am, pk2_am, offset, ..]
+    and                      ; [pk2, pk2_am, offset, ..]
 
-  ;; Store pk2 at offset = i*RECORD_SIZE + 52.
-  dup3                  ;; [offset, pk2, pk2_am, offset, ..]
-  mstore                ;; [pk2_am, offset, ..]
-  swap1                 ;; [offset, pk2_am, ..]
-  push 16               ;; [16, offset, pk2_am, ..]
-  add                   ;; [offset=offset+16, pk2_am, ..]
+    ;; Store pk2 at offset = i*RECORD_SIZE + 52.
+    dup3                     ; [offset, pk2, pk2_am, offset, ..]
+    mstore                   ; [pk2_am, offset, ..]
+    swap1                    ; [offset, pk2_am, ..]
+    push 16                  ; [16, offset, pk2_am, ..]
+    add                      ; [offset=offset+16, pk2_am, ..]
 
-  ;; Extract am from pk2_am.
-  swap1                 ;; [pk2_am, offset, slotbase, ..]
-  push 8*8              ;; [shft, pk2_am, offset, ..]
-  shr                   ;; [am, offset, ..]
+    ;; Extract am from pk2_am.
+    swap1                    ; [pk2_am, offset, slotbase, ..]
+    push 8 * 8               ; [shft, pk2_am, offset, ..]
+    shr                      ; [am, offset, ..]
 
-  ;; Store am at offset = i*RECORD_SIZE + 68.
-  ;; Note we convert to little-endian.
-  swap1                 ;; [offset, am, ..]
-  %mstore_uint64_le()   ;; [i, ..]
+    ;; Store am at offset = i*RECORD_SIZE + 68.
+    ;; Note we convert to little-endian.
+    swap1                    ; [offset, am, ..]
+    %mstore_uint64_le        ; [i, ..]
 
-  ;; Increment i.
-  push 1                ;; [1, i, ..]
-  add                   ;; [i+1, ..]
+    ;; Increment i.
+    push 1                   ; [1, i, ..]
+    add                      ; [i+1, ..]
 
-  jump @accum_loop      ;; [i, count, head_idx, tail_idx]
+    jump @accum_loop         ; [i, count, head_idx, tail_idx]
 
 update_head:
-  ;; All requests have been read, update queue by adding the count read to the
-  ;; current head index.
-  swap2                 ;; [head_idx, count, count, tail_idx]
-  add                   ;; [new_head_idx, count, tail_idx]
+    ;; All requests have been read, update queue by adding the count read to the
+    ;; current head index.
+    swap2                    ; [head_idx, count, count, tail_idx]
+    add                      ; [new_head_idx, count, tail_idx]
 
-  ;; If the new head is equal to the tail, reset the queue by zeroing them both.
-  dup1                  ;; [new_head_idx, new_head_idx, count, tail_idx]
-  swap3                 ;; [tail_idx, new_head_idx, count, new_head_idx]
-  eq                    ;; [new_head_idx == tail_idx, count, new_head_idx]
-  jumpi @reset_queue    ;; [count, new_head_idx]
+    ;; If the new head is equal to the tail, reset the queue by zeroing them both.
+    dup1                     ; [new_head_idx, new_head_idx, count, tail_idx]
+    swap3                    ; [tail_idx, new_head_idx, count, new_head_idx]
+    eq                       ; [new_head_idx == tail_idx, count, new_head_idx]
+    jumpi @reset_queue       ; [count, new_head_idx]
 
-  ;; Otherwise, write the new head to storage.
-  swap1                 ;; [new_head_idx, count]
-  push QUEUE_HEAD       ;; [head_idx_slot, new_head_idx, count]
-  sstore                ;; [count]
+    ;; Otherwise, write the new head to storage.
+    swap1                    ; [new_head_idx, count]
+    push QUEUE_HEAD          ; [head_idx_slot, new_head_idx, count]
+    sstore                   ; [count]
 
-  jump @update_excess   ;; [count]
+    jump @update_excess      ; [count]
 
 reset_queue:
-  ;; Since the queue is empty, both the head and tail indexes can be zeroed.
-  swap1                 ;; [new_head_idx, count]
-  pop                   ;; [count]
+    ;; Since the queue is empty, both the head and tail indexes can be zeroed.
+    swap1                    ; [new_head_idx, count]
+    pop                      ; [count]
 
-  push 0                ;; [0, count]
-  push QUEUE_HEAD       ;; [head_slot, 0, count]
-  sstore                ;; [count]
+    push 0                   ; [0, count]
+    push QUEUE_HEAD          ; [head_slot, 0, count]
+    sstore                   ; [count]
 
-  push 0                ;; [0, count]
-  push QUEUE_TAIL       ;; [tail_slot, 0, count]
-  sstore                ;; [count]
+    push 0                   ; [0, count]
+    push QUEUE_TAIL          ; [tail_slot, 0, count]
+    sstore                   ; [count]
 
 update_excess:
-  ;; Update the new excess withdrawal requests.
-  push SLOT_EXCESS      ;; [excess_slot, count]
-  sload                 ;; [excess, count]
+    ;; Update the new excess withdrawal requests.
+    push SLOT_EXCESS         ; [excess_slot, count]
+    sload                    ; [excess, count]
 
-  ;; Check if excess needs to be reset to 0 for first iteration after
-  ;; activation.
-  dup1                  ;; [excess, excess, count]
-  push EXCESS_INHIBITOR ;; [inhibitor, excess, excess, count]
-  eq                    ;; [inhibitor == excess, excess, count]
-  iszero                ;; [inhibitor != excess, excess, count]
-  jumpi @skip_reset     ;; [excess, count]
+    ;; Check if excess needs to be reset to 0 for first iteration after
+    ;; activation.
+    dup1                     ; [excess, excess, count]
+    push EXCESS_INHIBITOR    ; [inhibitor, excess, excess, count]
+    eq                       ; [inhibitor == excess, excess, count]
+    iszero                   ; [inhibitor != excess, excess, count]
+    jumpi @skip_reset        ; [excess, count]
 
-  ;; Drop the count from stack and use 0.
-  pop                   ;; [count]
-  push 0                ;; [reset_excess]
+    ;; Drop the count from stack and use 0.
+    pop                      ; [count]
+    push 0                   ; [reset_excess]
 
 skip_reset:
-  push SLOT_COUNT       ;; [count_slot, excess, count]
-  sload                 ;; [count, excess, count]
+    push SLOT_COUNT          ; [count_slot, excess, count]
+    sload                    ; [count, excess, count]
 
-  ;; If the sum of the previous excess requests and requests added in the
-  ;; current block is greater than the target, subtract the target from the sum
-  ;; and set it as the new excess withdrawal requests value.
-  push TARGET_PER_BLOCK ;; [target, count, excess, count]
-  dup3                  ;; [excess, target, count, excess, count]
-  dup3                  ;; [count, excess, target, count, excess, count]
-  add                   ;; [count+excess, target, count, excess, count]
-  gt                    ;; [count+excess > target, count, excess, count]
-  jumpi @compute_excess ;; [count, excess, count]
+    ;; If the sum of the previous excess requests and requests added in the
+    ;; current block is greater than the target, subtract the target from the sum
+    ;; and set it as the new excess withdrawal requests value.
+    push TARGET_PER_BLOCK    ; [target, count, excess, count]
+    dup3                     ; [excess, target, count, excess, count]
+    dup3                     ; [count, excess, target, count, excess, count]
+    add                      ; [count+excess, target, count, excess, count]
+    gt                       ; [count+excess > target, count, excess, count]
+    jumpi @compute_excess    ; [count, excess, count]
 
-  ;; Zero out excess.
-  pop                   ;; [excess, count]
-  pop                   ;; [count]
-  push 0                ;; [0, count]
-  jump @store_excess    ;; [0, count]
+    ;; Zero out excess.
+    pop                      ; [excess, count]
+    pop                      ; [count]
+    push 0                   ; [0, count]
+    jump @store_excess       ; [0, count]
 
 compute_excess:
-  add                   ;; [count+excess, count]
-  push TARGET_PER_BLOCK ;; [target, count+excess, count]
-  swap1                 ;; [count+excess, target, count]
-  sub                   ;; [new_excess, count]
+    add                      ; [count+excess, count]
+    push TARGET_PER_BLOCK    ; [target, count+excess, count]
+    swap1                    ; [count+excess, target, count]
+    sub                      ; [new_excess, count]
 
 store_excess:
-  push SLOT_EXCESS      ;; [excess_slot, new_excess, count]
-  sstore                ;; [count]
+    push SLOT_EXCESS         ; [excess_slot, new_excess, count]
+    sstore                   ; [count]
 
-  ;; Reset withdrawal request count.
-  push 0                ;; [0, count]
-  push SLOT_COUNT       ;; [count_slot, 0, count]
-  sstore                ;; [count]
+    ;; Reset withdrawal request count.
+    push 0                   ; [0, count]
+    push SLOT_COUNT          ; [count_slot, 0, count]
+    sstore                   ; [count]
 
-  ;; Return the withdrawal requests.
-  push RECORD_SIZE      ;; [record_size, count]
-  mul                   ;; [size]
-  push 0                ;; [0, size]
-  return                ;; []
+    ;; Return the withdrawal requests.
+    push RECORD_SIZE         ; [record_size, count]
+    mul                      ; [size]
+    push 0                   ; [0, size]
+    return                   ; []
 
-;; Revert subroutine.
+    ;; Revert subroutine.
 revert:
-  push 0
-  push 0
-  revert
+    push 0
+    push 0
+    revert
 
-;; ----------------------------------------------------------------------------
-;; MACROS ---------------------------------------------------------------------
-;; ----------------------------------------------------------------------------
+;;; ----------------------------------------------------------------------------
+;;; MACROS ---------------------------------------------------------------------
+;;; ----------------------------------------------------------------------------
 
-;; This defines a mask for accessing the top 16 bytes of a number.
+;;; This defines a mask for accessing the top 16 bytes of a number.
 #define pk2_mask = 0xffffffffffffffffffffffffffffffff00000000000000000000000000000000
 
-;; Helper for storing little-endian amount.
-#define %mstore_uint64_le() { ;; [offset, value]
-  dup2                  ;; [value, offset, value]
-  push 7*8              ;; [56, value, offset, value]
-  shr                   ;; [value>>56, offset, value]
-  dup2                  ;; [offset, value>>56, offset, value]
-  push 7                ;; [7, offset, value>>56, offset, value]
-  add                   ;; [offset+7, value>>56, offset, value]
-  mstore8               ;; [offset, value]
+;;; Helper for storing little-endian amount.
+#define %mstore_uint64_le {  ; [offset, value]
+    dup2                     ; [value, offset, value]
+    push 7 * 8               ; [56, value, offset, value]
+    shr                      ; [value>>56, offset, value]
+    dup2                     ; [offset, value>>56, offset, value]
+    push 7                   ; [7, offset, value>>56, offset, value]
+    add                      ; [offset+7, value>>56, offset, value]
+    mstore8                  ; [offset, value]
 
-  dup2                  ;; [value, offset, value]
-  push 6*8              ;; [48, value, offset, value]
-  shr                   ;; [value>>48, offset, value]
-  dup2                  ;; [offset, value>>48, offset, value]
-  push 6                ;; [6, offset, value>>48, offset, value]
-  add                   ;; [offset+6, value>>48, offset, value]
-  mstore8               ;; [offset, value]
+    dup2                     ; [value, offset, value]
+    push 6 * 8               ; [48, value, offset, value]
+    shr                      ; [value>>48, offset, value]
+    dup2                     ; [offset, value>>48, offset, value]
+    push 6                   ; [6, offset, value>>48, offset, value]
+    add                      ; [offset+6, value>>48, offset, value]
+    mstore8                  ; [offset, value]
 
-  dup2                  ;; [value, offset, value]
-  push 5*8              ;; [40, value, offset, value]
-  shr                   ;; [value>>40, offset, value]
-  dup2                  ;; [offset, value>>40, offset, value]
-  push 5                ;; [5, offset, value>>40, offset, value]
-  add                   ;; [offset+5, value>>40, offset, value]
-  mstore8               ;; [offset, value]
+    dup2                     ; [value, offset, value]
+    push 5 * 8               ; [40, value, offset, value]
+    shr                      ; [value>>40, offset, value]
+    dup2                     ; [offset, value>>40, offset, value]
+    push 5                   ; [5, offset, value>>40, offset, value]
+    add                      ; [offset+5, value>>40, offset, value]
+    mstore8                  ; [offset, value]
 
-  dup2                  ;; [value, offset, value]
-  push 4*8              ;; [32, value, offset, value]
-  shr                   ;; [value>>32, offset, value]
-  dup2                  ;; [offset, value>>32, offset, value]
-  push 4                ;; [4, offset, value>>32, offset, value]
-  add                   ;; [offset+4, value>>32, offset, value]
-  mstore8               ;; [offset, value]
+    dup2                     ; [value, offset, value]
+    push 4 * 8               ; [32, value, offset, value]
+    shr                      ; [value>>32, offset, value]
+    dup2                     ; [offset, value>>32, offset, value]
+    push 4                   ; [4, offset, value>>32, offset, value]
+    add                      ; [offset+4, value>>32, offset, value]
+    mstore8                  ; [offset, value]
 
-  dup2                  ;; [value, offset, value]
-  push 3*8              ;; [24, value, offset, value]
-  shr                   ;; [value>>24, offset, value]
-  dup2                  ;; [offset, value>>24, offset, value]
-  push 3                ;; [3, offset, value>>24, offset, value]
-  add                   ;; [offset+3, value>>24, offset, value]
-  mstore8               ;; [offset, value]
+    dup2                     ; [value, offset, value]
+    push 3 * 8               ; [24, value, offset, value]
+    shr                      ; [value>>24, offset, value]
+    dup2                     ; [offset, value>>24, offset, value]
+    push 3                   ; [3, offset, value>>24, offset, value]
+    add                      ; [offset+3, value>>24, offset, value]
+    mstore8                  ; [offset, value]
 
-  dup2                  ;; [value, offset, value]
-  push 2*8              ;; [16, value, offset, value]
-  shr                   ;; [value>>16, offset, value]
-  dup2                  ;; [offset, value>>16, offset, value]
-  push 2                ;; [2, offset, value>>16, offset, value]
-  add                   ;; [offset+2, value>>16, offset, value]
-  mstore8               ;; [offset, value]
+    dup2                     ; [value, offset, value]
+    push 2 * 8               ; [16, value, offset, value]
+    shr                      ; [value>>16, offset, value]
+    dup2                     ; [offset, value>>16, offset, value]
+    push 2                   ; [2, offset, value>>16, offset, value]
+    add                      ; [offset+2, value>>16, offset, value]
+    mstore8                  ; [offset, value]
 
-  dup2                  ;; [value, offset, value]
-  push 1*8              ;; [8, value, offset, value]
-  shr                   ;; [value>>8, offset, value]
-  dup2                  ;; [offset, value>>8, offset, value]
-  push 1                ;; [1, offset, value>>8, offset, value]
-  add                   ;; [offset+1, value>>8, offset, value]
-  mstore8               ;; [offset, value]
+    dup2                     ; [value, offset, value]
+    push 1 * 8               ; [8, value, offset, value]
+    shr                      ; [value>>8, offset, value]
+    dup2                     ; [offset, value>>8, offset, value]
+    push 1                   ; [1, offset, value>>8, offset, value]
+    add                      ; [offset+1, value>>8, offset, value]
+    mstore8                  ; [offset, value]
 
-  mstore8               ;; []
+    mstore8                  ; []
 }


### PR DESCRIPTION
This PR adapts the commenting style to the canonical one explained in the geas README,
and applies `geas -f` on all source code. Specifically, the geas style is using `;;;` for top-level
comments, `;;` for indented comments, and `;` for end-of-line comments.

Note this also changes the indentation to four spaces everywhere. 

There are no changes to bytecode, as verified by checkhash.