### PR TITLE
.github: check for modified bytecode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,14 @@ jobs:
           make build
         id: build
 
+      - name: Ensure bytecode files are up-to-date
+        run: |
+          if ! git diff --exit-code -- bytecode; then
+              echo "::error::bytecode files modified during the build. Run `make build` locally and commit the result."
+              git status
+              exit 1
+          fi
+
       - name: Run Forge build
         # this is mostly here so that warnings from building forge-std
         # do not appear in the test output

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,10 @@ jobs:
           make build
         id: build
 
-      - name: Ensure bytecode files are up-to-date
+      - name: Ensure committed bytecode files are up-to-date
         run: |
           if ! git diff --exit-code -- bytecode; then
-              echo "::error::bytecode files modified during the build. Run `make build` locally and commit the result."
+              echo "::error::bytecode files modified during the build. Run 'make build' locally and commit the result."
               git status
               exit 1
           fi

--- a/src/consolidations/main.eas
+++ b/src/consolidations/main.eas
@@ -40,9 +40,6 @@
 ;;; PROGRAM START --------------------------------------------------------------
 ;;; ----------------------------------------------------------------------------
 
-    push 1
-    pop
-
     ;; Protect the system subroutine by checking if the caller is the system
     ;; address.
     caller                 ; [caller]

--- a/src/consolidations/main.eas
+++ b/src/consolidations/main.eas
@@ -40,6 +40,9 @@
 ;;; PROGRAM START --------------------------------------------------------------
 ;;; ----------------------------------------------------------------------------
 
+    push 1
+    pop
+
     ;; Protect the system subroutine by checking if the caller is the system
     ;; address.
     caller                 ; [caller]


### PR DESCRIPTION
Adding a build step that checks if any committed bytecode files are changed after running `make build`. This is supposed to ensure people can't submit changes without committing up-to-date bytecode.